### PR TITLE
[SID-679] Adjust Form component box sizing

### DIFF
--- a/.changeset/modern-dogs-swim.md
+++ b/.changeset/modern-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Set `box-sizing: border-box` on <Form/>

--- a/packages/react/src/components/form/form.css.ts
+++ b/packages/react/src/components/form/form.css.ts
@@ -7,6 +7,7 @@ export const form = style({
   backgroundColor: publicVariables.color.panel,
   width: "100%",
   padding: "20px",
+  boxSizing: "border-box",
 
   "@media": {
     "screen and (min-width: 768px)": {


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-679)

We want to set the `box-sizing: border-box` on the Form component to make it easier for users to set desired width for the whole form.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files