### PR TITLE
[SID-680] Form onSuccess props

### DIFF
--- a/.changeset/silver-files-pretend.md
+++ b/.changeset/silver-files-pretend.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add onSuccess callback prop to <Form /> component

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -75,6 +75,23 @@ describe("#Form", () => {
   test("should show the success state on successful login", async () => {
     const logInMock = vi.fn(() => Promise.resolve(TEST_USER));
     const user = userEvent.setup();
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+        <Form />
+      </TestSlashIDProvider>
+    );
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(
+      screen.findByTestId("sid-form-success-state")
+    ).resolves.toBeInTheDocument();
+  });
+
+  test("should call the onSuccess callback if provided on a successful login", async () => {
+    const logInMock = vi.fn(() => Promise.resolve(TEST_USER));
+    const user = userEvent.setup();
     const onSuccess = vi.fn();
 
     render(
@@ -90,6 +107,7 @@ describe("#Form", () => {
     ).resolves.toBeInTheDocument();
 
     expect(onSuccess).toBeCalledTimes(1);
+    expect(onSuccess).toBeCalledWith(TEST_USER);
   });
 
   test("should show the error state if login fails", async () => {

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -75,10 +75,11 @@ describe("#Form", () => {
   test("should show the success state on successful login", async () => {
     const logInMock = vi.fn(() => Promise.resolve(TEST_USER));
     const user = userEvent.setup();
+    const onSuccess = vi.fn();
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <Form onSuccess={onSuccess} />
       </TestSlashIDProvider>
     );
 
@@ -87,6 +88,8 @@ describe("#Form", () => {
     await expect(
       screen.findByTestId("sid-form-success-state")
     ).resolves.toBeInTheDocument();
+
+    expect(onSuccess).toBeCalledTimes(1);
   });
 
   test("should show the error state if login fails", async () => {

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -1,5 +1,6 @@
 import { clsx } from "clsx";
 import { useFlowState } from "./useFlowState";
+import { CreateFlowOptions } from "./flow";
 import { Initial } from "./initial";
 import { Authenticating } from "./authenticating";
 import { Error } from "./error";
@@ -11,11 +12,11 @@ import { useConfiguration } from "../../hooks/use-configuration";
 
 export type Props = {
   className?: string;
-  onSuccess?: () => void;
+  onSuccess?: CreateFlowOptions["onSuccess"];
 };
 
 export const Form: React.FC<Props> = ({ className, onSuccess }) => {
-  const flowState = useFlowState();
+  const flowState = useFlowState({ onSuccess });
   const { theme } = useConfiguration();
 
   return (
@@ -34,9 +35,7 @@ export const Form: React.FC<Props> = ({ className, onSuccess }) => {
         <Authenticating flowState={flowState} />
       )}
       {flowState.status === "error" && <Error flowState={flowState} />}
-      {flowState.status === "success" && (
-        <Success flowState={flowState} onSuccess={onSuccess} />
-      )}
+      {flowState.status === "success" && <Success flowState={flowState} />}
       <Footer />
     </div>
   );

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -11,9 +11,10 @@ import { useConfiguration } from "../../hooks/use-configuration";
 
 export type Props = {
   className?: string;
+  onSuccess?: () => void;
 };
 
-export const Form: React.FC<Props> = ({ className }) => {
+export const Form: React.FC<Props> = ({ className, onSuccess }) => {
   const flowState = useFlowState();
   const { theme } = useConfiguration();
 
@@ -33,7 +34,9 @@ export const Form: React.FC<Props> = ({ className }) => {
         <Authenticating flowState={flowState} />
       )}
       {flowState.status === "error" && <Error flowState={flowState} />}
-      {flowState.status === "success" && <Success flowState={flowState} />}
+      {flowState.status === "success" && (
+        <Success flowState={flowState} onSuccess={onSuccess} />
+      )}
       <Footer />
     </div>
   );

--- a/packages/react/src/components/form/success.tsx
+++ b/packages/react/src/components/form/success.tsx
@@ -1,5 +1,4 @@
 import { clsx } from "clsx";
-import { useEffect, useCallback } from "react";
 import { SuccessState } from "./flow";
 import { Text } from "../text";
 import { centered, sprinkles } from "../../theme/sprinkles.css";
@@ -21,20 +20,9 @@ const CheckIcon = () => (
 
 type Props = {
   flowState: SuccessState;
-  onSuccess?: () => void;
 };
 
-export const Success: React.FC<Props> = ({ onSuccess }) => {
-  const handleSuccess = useCallback(() => {
-    if (onSuccess) {
-      onSuccess();
-    }
-  }, [onSuccess]);
-
-  useEffect(() => {
-    handleSuccess();
-  }, [handleSuccess]);
-
+export const Success: React.FC<Props> = () => {
   return (
     <article data-testid="sid-form-success-state">
       <Text as="h1" t="success.title" variant={{ size: "2xl-title" }} />

--- a/packages/react/src/components/form/success.tsx
+++ b/packages/react/src/components/form/success.tsx
@@ -1,4 +1,5 @@
 import { clsx } from "clsx";
+import { useEffect, useCallback } from "react";
 import { SuccessState } from "./flow";
 import { Text } from "../text";
 import { centered, sprinkles } from "../../theme/sprinkles.css";
@@ -20,9 +21,20 @@ const CheckIcon = () => (
 
 type Props = {
   flowState: SuccessState;
+  onSuccess?: () => void;
 };
 
-export const Success: React.FC<Props> = () => {
+export const Success: React.FC<Props> = ({ onSuccess }) => {
+  const handleSuccess = useCallback(() => {
+    if (onSuccess) {
+      onSuccess();
+    }
+  }, [onSuccess]);
+
+  useEffect(() => {
+    handleSuccess();
+  }, [handleSuccess]);
+
   return (
     <article data-testid="sid-form-success-state">
       <Text as="h1" t="success.title" variant={{ size: "2xl-title" }} />

--- a/packages/react/src/components/form/useFlowState.ts
+++ b/packages/react/src/components/form/useFlowState.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 
 import { useSlashID } from "../../hooks/use-slash-id";
-import { Flow, createFlow, FlowState } from "./flow";
+import { Flow, createFlow, FlowState, CreateFlowOptions } from "./flow";
 
-export function useFlowState() {
+export function useFlowState(opts: CreateFlowOptions = {}) {
   const { logIn } = useSlashID();
-  const flowRef = useRef<Flow>(createFlow());
+  const flowRef = useRef<Flow>(createFlow(opts));
   const [state, setState] = useState<FlowState>(flowRef.current.state);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-680)

There is a common requirement for a callback prop fired when the authentication via `<Form />` component is successful

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have updated the README and DEVELOPMENT files