### PR TITLE
[SID-850] Exclude font from the bundle

### DIFF
--- a/.changeset/tidy-mangos-bake.md
+++ b/.changeset/tidy-mangos-bake.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Reduce CSS bundle size - exclude Inter font

--- a/packages/react/index.html
+++ b/packages/react/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,6 @@
     "test:unit:watch": "vitest"
   },
   "dependencies": {
-    "@fontsource/inter": "^4.5.14",
     "@radix-ui/react-select": "^1.1.2",
     "@radix-ui/react-tabs": "^1.0.1",
     "@vanilla-extract/css": "^1.9.2",

--- a/packages/react/src/components/form/index.tsx
+++ b/packages/react/src/components/form/index.tsx
@@ -1,6 +1,2 @@
-import "@fontsource/inter/400.css";
-import "@fontsource/inter/500.css";
-import "@fontsource/inter/600.css";
-
 export { Form } from "./form";
-export type { Props as FormProps  } from "./form";
+export type { Props as FormProps } from "./form";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,6 @@ importers:
 
   packages/react:
     specifiers:
-      '@fontsource/inter': ^4.5.14
       '@radix-ui/react-select': ^1.1.2
       '@radix-ui/react-tabs': ^1.0.1
       '@slashid/slashid': ^3.3.2
@@ -220,7 +219,6 @@ importers:
       vite: ^3.1.0
       vitest: ^0.25.2
     dependencies:
-      '@fontsource/inter': 4.5.14
       '@radix-ui/react-select': 1.1.2_sd644w7yfdyrvmykkrrqd5kd4a
       '@radix-ui/react-tabs': 1.0.1_biqbaboplfbrettd7655fr4n2y
       '@vanilla-extract/css': 1.9.2


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-850)

We want to exclude Inter font from our CSS bundle - with the font the file is ~4MiB, without ~22KiB

<img width="336" alt="Screenshot 2023-04-12 at 10 16 35" src="https://user-images.githubusercontent.com/29861461/231396080-8083ed30-0e23-4b97-92a6-a7242cab4367.png">


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have updated the README and DEVELOPMENT files