### PR TITLE
Use sans-serif as default font

### DIFF
--- a/.changeset/gold-berries-attack.md
+++ b/.changeset/gold-berries-attack.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Add sans-serif font as a fallback

--- a/.changeset/gold-berries-attack.md
+++ b/.changeset/gold-berries-attack.md
@@ -2,4 +2,4 @@
 "@slashid/react": patch
 ---
 
-Add sans-serif font as a fallback
+Use sans-serif as a default font

--- a/packages/react/index.html
+++ b/packages/react/index.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/react/src/theme/theme.css.ts
+++ b/packages/react/src/theme/theme.css.ts
@@ -119,7 +119,7 @@ export const darkThemeColors = {
 export const lightTheme = {
   color: lightThemeColors,
   font: {
-    fontFamily: "Inter, sans-serif",
+    fontFamily: "sans-serif",
   },
   border: {
     radius: "16px",

--- a/packages/react/src/theme/theme.css.ts
+++ b/packages/react/src/theme/theme.css.ts
@@ -119,7 +119,7 @@ export const darkThemeColors = {
 export const lightTheme = {
   color: lightThemeColors,
   font: {
-    fontFamily: "Inter",
+    fontFamily: "Inter, sans-serif",
   },
   border: {
     radius: "16px",


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-000)

Add sans-serif as font fallback

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have updated the README and DEVELOPMENT files