### PR TITLE
[SID-887] Make the react package public

### DIFF
--- a/.changeset/selfish-ties-return.md
+++ b/.changeset/selfish-ties-return.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Make the package public

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@slashid/react",
   "version": "1.5.1",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/slashid/javascript.git"


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-887)

`@slashid/react` is supposed to be public.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files