### PR TITLE
[SID-967] Change 'WebAuthn' wording to 'Passkeys'

### DIFF
--- a/.changeset/eighty-vans-explode.md
+++ b/.changeset/eighty-vans-explode.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Adjust wording to more user-friendly (WebAuthn -> Passkeys)

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -40,7 +40,7 @@ export const TEXT = {
   "error.title": "Something went wrong...",
   "error.subtitle":
     "There has been an error while submitting your form. Please try again.",
-  "factor.webauthn": "Webauthn",
+  "factor.webauthn": "Passkeys",
   "factor.otpViaSms": "OTP via SMS",
   "factor.emailLink": "Email link",
   "factor.smsLink": "SMS link",


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-967)

Most users will not know what Webauthn means, so using Passkeys will give a more friendly experience.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have updated the README and DEVELOPMENT files