### PR TITLE
[SID-948] Allow passing in an external token to the SDK

### DIFF
--- a/.changeset/few-papayas-collect.md
+++ b/.changeset/few-papayas-collect.md
@@ -2,4 +2,4 @@
 "@slashid/react": minor
 ---
 
-Add the "token" prop to the SlashIDProvider
+Add the "initialToken" prop to the SlashIDProvider

--- a/.changeset/few-papayas-collect.md
+++ b/.changeset/few-papayas-collect.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add the "token" prop to the SlashIDProvider

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -15,6 +15,7 @@ export type StorageOption = "memory" | "localStorage";
 
 export interface SlashIDProviderProps {
   oid: string;
+  token?: string;
   tokenStorage?: StorageOption;
   baseApiUrl?: string;
   sdkUrl?: string;
@@ -67,6 +68,7 @@ const createStorage = (storageType: StorageOption) => {
 
 export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
   oid,
+  token,
   tokenStorage = "memory",
   baseApiUrl,
   sdkUrl,
@@ -244,10 +246,14 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
     };
 
     const tryImmediateLogin = async () => {
-      const isDone = await loginDirectIdIfPresent();
+      if (token) {
+        storeUser(new User(token));
+      } else {
+        const isDone = await loginDirectIdIfPresent();
 
-      if (!isDone) {
-        await loginStoredToken();
+        if (!isDone) {
+          await loginStoredToken();
+        }
       }
 
       setState("ready");
@@ -255,7 +261,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
 
     setState("retrievingToken");
     tryImmediateLogin();
-  }, [state, storeUser, validateToken]);
+  }, [state, token, storeUser, validateToken]);
 
   const contextValue = useMemo(() => {
     if (state === "initial") {

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -15,7 +15,7 @@ export type StorageOption = "memory" | "localStorage";
 
 export interface SlashIDProviderProps {
   oid: string;
-  token?: string;
+  initialToken?: string;
   tokenStorage?: StorageOption;
   baseApiUrl?: string;
   sdkUrl?: string;
@@ -68,7 +68,7 @@ const createStorage = (storageType: StorageOption) => {
 
 export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
   oid,
-  token,
+  initialToken,
   tokenStorage = "memory",
   baseApiUrl,
   sdkUrl,
@@ -246,8 +246,8 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
     };
 
     const tryImmediateLogin = async () => {
-      if (token) {
-        storeUser(new User(token));
+      if (initialToken) {
+        storeUser(new User(initialToken));
       } else {
         const isDone = await loginDirectIdIfPresent();
 
@@ -261,7 +261,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
 
     setState("retrievingToken");
     tryImmediateLogin();
-  }, [state, token, storeUser, validateToken]);
+  }, [state, initialToken, storeUser, validateToken]);
 
   const contextValue = useMemo(() => {
     if (state === "initial") {

--- a/packages/react/src/context/test-slash-id-provider.tsx
+++ b/packages/react/src/context/test-slash-id-provider.tsx
@@ -10,6 +10,10 @@ type TestProviderProps = Partial<ISlashIDContext> & {
   children: React.ReactNode;
 };
 
+export const TEST_ORG_ID = "ad5399ea-4e88-b04a-16ca-82958c955740";
+export const TEST_PERSON_ID =
+  "pid:01e43f2419fe994879a64564cd76ab30a8d2ea95e89987c8185cef5ab8f8adf8de643a289c:2";
+
 const TEST_TOKEN_HEADER = "eyJhbGciOiJSUzI1NiIsICJraWQiOiJ2RXBzRmcifQ";
 const TEST_TOKEN_PAYLOAD_DECODED = {
   authenticated_methods: ["email_link"],
@@ -19,9 +23,8 @@ const TEST_TOKEN_PAYLOAD_DECODED = {
   iat: 1668767017,
   iss: "https://sandbox.slashid.dev",
   jti: "039bbb27c07b69b21762ec0a1a9c2dc5",
-  oid: "ad5399ea-4e88-b04a-16ca-82958c955740",
-  user_id:
-    "pid:01e43f2419fe994879a64564cd76ab30a8d2ea95e89987c8185cef5ab8f8adf8de643a289c:2",
+  oid: TEST_ORG_ID,
+  person_id: TEST_PERSON_ID,
 };
 
 const TEST_TOKEN_SIGNATURE =

--- a/packages/react/src/hooks/use-slash-id.test.tsx
+++ b/packages/react/src/hooks/use-slash-id.test.tsx
@@ -18,14 +18,14 @@ const TestComponent = () => {
 };
 
 describe("useSlashID", () => {
-  test("should return a user instance when a valid token is passed to the SlashIDProvider", async () => {
+  test("should return a user instance when a valid initial token is passed to the SlashIDProvider", async () => {
     render(
-      <SlashIDProvider token={TEST_TOKEN} oid={TEST_ORG_ID}>
+      <SlashIDProvider initialToken={TEST_TOKEN} oid={TEST_ORG_ID}>
         <TestComponent />
       </SlashIDProvider>
     );
 
-    // expect.assertions(1);
+    expect.assertions(1);
     await expect(
       screen.findByText(TEST_PERSON_ID)
     ).resolves.toBeInTheDocument();

--- a/packages/react/src/hooks/use-slash-id.test.tsx
+++ b/packages/react/src/hooks/use-slash-id.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import {
+  TEST_ORG_ID,
+  TEST_PERSON_ID,
+  TEST_TOKEN,
+} from "../context/test-slash-id-provider";
+import { SlashIDProvider } from "../main";
+import { useSlashID } from "./use-slash-id";
+
+const TestComponent = () => {
+  const { user } = useSlashID();
+
+  if (!user) {
+    return <div>Not logged in</div>;
+  }
+
+  return <div>{user.ID}</div>;
+};
+
+describe("useSlashID", () => {
+  test("should return a user instance when a valid token is passed to the SlashIDProvider", async () => {
+    render(
+      <SlashIDProvider token={TEST_TOKEN} oid={TEST_ORG_ID}>
+        <TestComponent />
+      </SlashIDProvider>
+    );
+
+    // expect.assertions(1);
+    await expect(
+      screen.findByText(TEST_PERSON_ID)
+    ).resolves.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-948)

Allow passing in an external token to the SDK (some clients might store the token somewhere else).

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files