### PR TITLE
[SID-1126] Add isLoading to SlashIDContext

### DIFF
--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -32,6 +32,7 @@ type SDKState =
 export interface ISlashIDContext {
   sid: SlashID | undefined;
   user: User | undefined;
+  isLoading: boolean;
   sdkState: SDKState;
   logOut: () => undefined;
   logIn: LogIn;
@@ -42,6 +43,7 @@ export interface ISlashIDContext {
 export const initialContextValue = {
   sid: undefined,
   user: undefined,
+  isLoading: true,
   sdkState: "initial" as const,
   logOut: () => undefined,
   logIn: () => Promise.reject("NYI"),
@@ -77,6 +79,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
 }) => {
   const [state, setState] = useState<SDKState>(initialContextValue.sdkState);
   const [user, setUser] = useState<User | undefined>(undefined);
+  const isLoading = useMemo(() => state !== 'ready', [state]);
   const storageRef = useRef<Storage | undefined>(undefined);
   const sidRef = useRef<SlashID | undefined>(undefined);
 
@@ -268,6 +271,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
       return {
         sid: undefined,
         user,
+        isLoading,
         sdkState: state,
         logOut,
         logIn,
@@ -279,6 +283,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
     return {
       sid: sidRef.current!,
       user,
+      isLoading,
       sdkState: state,
       logOut,
       logIn,


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1126)

There is no way to check via the `useSlashID()` hook if the SDK is currently "loading" without using internal `sdkState`. We have `<SlashIDLoaded />` but this only helps for composition in JSX, it doesn't satisfy the use case of early-return style conditional rendering.

See YouTrack for more detailed context.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files