### PR TITLE
fix: remove JSX.Element type from SlashIDLoaded props

### DIFF
--- a/.changeset/sour-gorillas-care.md
+++ b/.changeset/sour-gorillas-care.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Remove JSX.Element type from <SlashIDLoaded/>

--- a/packages/react/src/components/loaded/index.tsx
+++ b/packages/react/src/components/loaded/index.tsx
@@ -1,8 +1,8 @@
 import { useSlashID } from "../../main";
 
 interface Props {
-    fallback?: JSX.Element
-    children: JSX.Element
+    fallback?: React.ReactElement
+    children: React.ReactElement
 }
 
 /**
@@ -10,11 +10,11 @@ interface Props {
  * 
  * Acts as a guard for SlashID core SDK dependent operations. Can optionally render a fallback component while the SDK is loading.
  */
-export const SlashIDLoaded  = ({ fallback, children }: Props): JSX.Element => {
+export const SlashIDLoaded  = ({ fallback, children }: Props) => {
     const { isLoading } = useSlashID()
 
     if (isLoading) {
-        if (!fallback) return <></>
+        if (!fallback) return null
 
         return fallback
     }


### PR DESCRIPTION
## Description

I noticed when implementing `SlashIDLoaded` in `suborg-demo` that the prop types are clunky, I'm changing them.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files