### PR TITLE
chore: re-publish @slashid/react

### DIFF
--- a/.changeset/proud-trees-raise.md
+++ b/.changeset/proud-trees-raise.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Remove JSX.Element type from


### PR DESCRIPTION
https://github.com/slashid/javascript/pull/100 didn't publish properly because we have a version conflict with a manually published version.

Trying to republish now, and in the changeset PR we can bump the version to a valid/available version number.