### PR TITLE
[SID-1146] Set the theme root on the SlashIDProvider level

### DIFF
--- a/.changeset/empty-scissors-share.md
+++ b/.changeset/empty-scissors-share.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Move the theme props to the SlashIDProvider

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -5,7 +5,6 @@ import { Initial } from "./initial";
 import { Authenticating } from "./authenticating";
 import { Error } from "./error";
 import { Success } from "./success";
-import { themeClass, darkTheme, autoTheme } from "../../theme/theme.css";
 import * as styles from "./form.css";
 import { Footer } from "./footer";
 import { useConfiguration } from "../../hooks/use-configuration";
@@ -28,20 +27,11 @@ export const Form: React.FC<Props> = ({
   text,
 }) => {
   const flowState = useFlowState({ onSuccess });
-  const { theme, showBanner } = useConfiguration();
+  const { showBanner } = useConfiguration();
   const { lastHandle } = useLastHandle();
 
   return (
-    <div
-      className={clsx(
-        "sid-theme-root",
-        `sid-theme-root__${theme}`,
-        themeClass,
-        { [darkTheme]: theme === "dark", [autoTheme]: theme === "auto" },
-        styles.form,
-        className
-      )}
-    >
+    <div className={clsx(styles.form, className)}>
       <ConfigurationOverrides text={text} factors={factors}>
         {flowState.status === "initial" && (
           <FormProvider>

--- a/packages/react/src/components/theme-root/index.tsx
+++ b/packages/react/src/components/theme-root/index.tsx
@@ -1,5 +1,5 @@
 import { clsx } from "clsx";
-import { Theme, autoTheme, darkTheme, themeClass } from "./theme.css";
+import { Theme, autoTheme, darkTheme, themeClass } from "../../theme/theme.css";
 
 export type ThemeProps = {
   theme?: Theme;

--- a/packages/react/src/context/config-context.tsx
+++ b/packages/react/src/context/config-context.tsx
@@ -2,14 +2,17 @@ import { Factor } from "@slashid/slashid";
 import { createContext, ReactNode, useMemo } from "react";
 import { TEXT, TextConfig } from "../components/text/constants";
 import { SlashID } from "../components/icon/slashid";
+import { Theme } from "../theme/theme.css";
 
 export type Logo = string | React.ReactNode;
 
-export type Theme = "light" | "dark" | "auto";
 export interface IConfigurationContext {
   text: TextConfig;
   factors: Factor[];
   logo: Logo;
+  /**
+   * @deprecated Set this on the SlashIDProvider instead using the themeProps prop.
+   */
   theme: Theme;
   storeLastHandle: boolean;
   showBanner: boolean;

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -11,7 +11,7 @@ import { PersonHandleType, SlashID, User } from "@slashid/slashid";
 import { MemoryStorage } from "../browser/memory-storage";
 import { LogIn, LoginOptions, MFA } from "../domain/types";
 import { SDKState } from "../domain/sdk-state";
-import { ThemeProps, ThemeRoot } from "../theme/theme-root";
+import { ThemeProps, ThemeRoot } from "../components/theme-root";
 
 export type StorageOption = "memory" | "localStorage";
 

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -11,6 +11,7 @@ import { PersonHandleType, SlashID, User } from "@slashid/slashid";
 import { MemoryStorage } from "../browser/memory-storage";
 import { LogIn, LoginOptions, MFA } from "../domain/types";
 import { SDKState } from "../domain/sdk-state";
+import { ThemeProps, ThemeRoot } from "../theme/theme-root";
 
 export type StorageOption = "memory" | "localStorage";
 
@@ -21,6 +22,7 @@ export interface SlashIDProviderProps {
   baseApiUrl?: string;
   sdkUrl?: string;
   analyticsEnabled?: boolean;
+  themeProps?: ThemeProps;
   children: React.ReactNode;
 }
 
@@ -68,6 +70,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
   baseApiUrl,
   sdkUrl,
   analyticsEnabled = false,
+  themeProps,
   children,
 }) => {
   const [state, setState] = useState<SDKState>(initialContextValue.sdkState);
@@ -272,7 +275,7 @@ export const SlashIDProvider: React.FC<SlashIDProviderProps> = ({
 
   return (
     <SlashIDContext.Provider value={contextValue}>
-      {children}
+      <ThemeRoot {...themeProps}>{children}</ThemeRoot>
     </SlashIDContext.Provider>
   );
 };

--- a/packages/react/src/dev.css
+++ b/packages/react/src/dev.css
@@ -16,3 +16,7 @@ body {
   width: 390px;
   margin: 32px;
 }
+
+.testClass {
+  --sid-color-primary: yellow;
+}

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -70,7 +70,10 @@ function Config() {
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <SlashIDProvider oid={import.meta.env.VITE_ORG_ID}>
+    <SlashIDProvider
+      oid={import.meta.env.VITE_ORG_ID}
+      themeProps={{ theme: "light", className: "testClass" }}
+    >
       <Config />
     </SlashIDProvider>
   </React.StrictMode>

--- a/packages/react/src/theme/theme-root.tsx
+++ b/packages/react/src/theme/theme-root.tsx
@@ -1,0 +1,33 @@
+import { clsx } from "clsx";
+import { Theme, autoTheme, darkTheme, themeClass } from "./theme.css";
+
+export type ThemeProps = {
+  theme?: Theme;
+  className?: string;
+};
+
+type Props = {
+  children: React.ReactNode;
+  theme?: ThemeProps["theme"];
+  className?: ThemeProps["className"];
+};
+
+/**
+ * This component is to be rendered as close as the app root.
+ * It sets the proper class names so that child components on all levels can use the theming properties.
+ */
+export function ThemeRoot({ children, theme = "light", className }: Props) {
+  return (
+    <div
+      className={clsx(
+        "sid-theme-root",
+        `sid-theme-root__${theme}`,
+        themeClass,
+        { [darkTheme]: theme === "dark", [autoTheme]: theme === "auto" },
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/react/src/theme/theme.css.ts
+++ b/packages/react/src/theme/theme.css.ts
@@ -211,3 +211,5 @@ export const [themeClass, theme] = createTheme({
     md: "4px 0px 24px rgba(29, 25, 77, 0.03), 0px 12px 32px rgba(29, 25, 77, 0.04)",
   },
 });
+
+export type Theme = "light" | "dark" | "auto";


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1146)

Set the theme root on the SlashIDProvider level to make sure all the components inherit the variables set there.
Marked the `theme` prop on the `ConfigurationProvider` as deprecated.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files