### PR TITLE
[SID-1165] React SDK: improve middleware sub-package interface

### DIFF
--- a/.changeset/ninety-scissors-help.md
+++ b/.changeset/ninety-scissors-help.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add <OrganizationSwitcher>, useOrganizations()

--- a/.changeset/tricky-toys-grow.md
+++ b/.changeset/tricky-toys-grow.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add middleware concept, defaultOrganization middleware

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -76,7 +76,7 @@
     "vitest": "^0.25.2"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.11.0",
+    "@slashid/slashid": ">= 3.12.0",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -13,7 +13,7 @@ import {
   SlashIDProvider,
   DynamicFlow,
 } from "./main";
-import { defaultOrganization } from "./middleware/default-organization";
+import { defaultOrganization } from "./middleware";
 import { Handle } from "./domain/types";
 
 const rootOid = "b6f94b67-d20f-7fc3-51df-bf6e3b82683e";

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -12,7 +12,7 @@ export interface LoginConfiguration {
   factor: Factor;
 }
 
-interface LoginMiddlewareContext {
+export interface LoginMiddlewareContext {
   user: User
   sid: SlashID
 }

--- a/packages/react/src/middleware/default-organization/default-organization.test.ts
+++ b/packages/react/src/middleware/default-organization/default-organization.test.ts
@@ -1,9 +1,9 @@
-import { defaultOrganization } from "./default-organization";
+import { defaultOrganization } from ".";
 import { faker } from "@faker-js/faker";
 import {
   createTestOrganization,
   createTestUser,
-} from "../components/test-utils";
+} from "../../components/test-utils";
 import { SlashID, User } from "@slashid/slashid";
 
 describe("middleware: defaultOrganization", () => {

--- a/packages/react/src/middleware/default-organization/index.ts
+++ b/packages/react/src/middleware/default-organization/index.ts
@@ -1,5 +1,5 @@
 import { OrganizationDetails, User } from "@slashid/slashid";
-import { LoginMiddleware } from "../domain/types";
+import { LoginMiddleware } from "../../domain/types";
 
 /**
  * Middleware: post-login switch the users organization context to another suborganization.

--- a/packages/react/src/middleware/index.ts
+++ b/packages/react/src/middleware/index.ts
@@ -1,7 +1,8 @@
-import { LoginMiddleware } from "../domain/types"
+import { LoginMiddleware, LoginMiddlewareContext } from "../domain/types"
 import { defaultOrganization } from "./default-organization"
 
 export {
   defaultOrganization,
-  type LoginMiddleware
+  type LoginMiddleware,
+  type LoginMiddlewareContext
 }

--- a/packages/react/src/middleware/index.ts
+++ b/packages/react/src/middleware/index.ts
@@ -1,0 +1,7 @@
+import { LoginMiddleware } from "../domain/types"
+import { defaultOrganization } from "./default-organization"
+
+export {
+  defaultOrganization,
+  type LoginMiddleware
+}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1165)

1. The `LoginMiddleware` interface is referenced in the doc but is not clearly available.
2. `defaultOrganization` is not available from the middleware index file

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have updated the README and DEVELOPMENT files