### PR TITLE
[SID-1171] Extend the OIDC config with a label option for UI overrides

### DIFF
--- a/.changeset/tidy-points-call.md
+++ b/.changeset/tidy-points-call.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Added the "label" option to OIDC factor config to enable overriding the UI label

--- a/packages/react/src/components/dynamic-flow/initial.tsx
+++ b/packages/react/src/components/dynamic-flow/initial.tsx
@@ -7,7 +7,7 @@ import { Text } from "../text";
 import { useConfiguration } from "../../hooks/use-configuration";
 import { ConfiguredHandleForm } from "../form/initial/configured-handle-form";
 import { Factor } from "@slashid/slashid";
-import { FactorOIDC, Handle, LoginOptions } from "../../domain/types";
+import { FactorLabeledOIDC, Handle, LoginOptions } from "../../domain/types";
 import { useMemo } from "react";
 import { isFactorOidc } from "../../domain/handles";
 
@@ -19,7 +19,7 @@ type Props = {
 
 export const Initial = ({ flowState, handleSubmit, middleware }: Props) => {
   const { logo, text, factors } = useConfiguration();
-  const oidcFactors: FactorOIDC[] = useMemo(
+  const oidcFactors: FactorLabeledOIDC[] = useMemo(
     () => factors.filter(isFactorOidc),
     [factors]
   );

--- a/packages/react/src/components/form/initial/index.tsx
+++ b/packages/react/src/components/form/initial/index.tsx
@@ -4,7 +4,7 @@ import { Factor } from "@slashid/slashid";
 import { Text } from "../../text";
 import { InitialState } from "../flow";
 import { useConfiguration } from "../../../hooks/use-configuration";
-import { FactorOIDC, Handle, LoginOptions } from "../../../domain/types";
+import { FactorLabeledOIDC, Handle, LoginOptions } from "../../../domain/types";
 import { isFactorOidc } from "../../../domain/handles";
 
 import { Logo } from "./logo";
@@ -24,7 +24,7 @@ export const Initial: React.FC<Props> = ({
 }) => {
   const { factors, logo } = useConfiguration();
 
-  const oidcFactors: FactorOIDC[] = useMemo(
+  const oidcFactors: FactorLabeledOIDC[] = useMemo(
     () => factors.filter(isFactorOidc),
     [factors]
   );

--- a/packages/react/src/components/form/initial/initial.css.ts
+++ b/packages/react/src/components/form/initial/initial.css.ts
@@ -4,3 +4,9 @@ export const oidcProvider = style({
   textTransform: "capitalize",
   marginLeft: "0.25rem",
 });
+
+export const oidcList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+});

--- a/packages/react/src/components/form/initial/oidc.tsx
+++ b/packages/react/src/components/form/initial/oidc.tsx
@@ -1,6 +1,6 @@
 import { Factor } from "@slashid/slashid";
 import clsx from "clsx";
-import { FactorOIDC } from "../../../domain/types";
+import { FactorLabeledOIDC } from "../../../domain/types";
 import { useConfiguration } from "../../../hooks/use-configuration";
 import { sprinkles } from "../../../theme/sprinkles.css";
 import { Button } from "../../button";
@@ -12,7 +12,6 @@ import { Github } from "../../icon/github";
 import { Gitlab } from "../../icon/gitlab";
 import { Google } from "../../icon/google";
 import { Line } from "../../icon/line";
-import { stack } from "../../stack/stack.css";
 
 import * as styles from "./initial.css";
 
@@ -28,7 +27,7 @@ const PROVIDER_TO_ICON: Record<string, React.ReactNode> = {
 };
 
 type Props = {
-  providers: FactorOIDC[];
+  providers: FactorLabeledOIDC[];
   handleClick: (factor: Factor) => void;
 };
 
@@ -39,7 +38,7 @@ export const Oidc: React.FC<Props> = ({ providers, handleClick }) => {
   }
 
   return (
-    <div className={clsx(stack, sprinkles({ marginTop: "4" }))}>
+    <div className={clsx(sprinkles({ marginTop: "4" }), styles.oidcList)}>
       {providers.map((p) => {
         if (!p.options?.provider) {
           return null;
@@ -47,13 +46,16 @@ export const Oidc: React.FC<Props> = ({ providers, handleClick }) => {
 
         return (
           <Button
-            key={p.options?.provider}
+            key={p.options?.client_id}
             onClick={() => handleClick({ method: "oidc", options: p.options })}
             variant="secondary"
             icon={PROVIDER_TO_ICON[p.options?.provider]}
+            className={clsx("sid-oidc--button")}
           >
             {text["initial.oidc"]}
-            <span className={styles.oidcProvider}>{p.options?.provider}</span>
+            <span className={styles.oidcProvider}>
+              {p.label || p.options?.provider}
+            </span>
           </Button>
         );
       })}

--- a/packages/react/src/context/config-context.tsx
+++ b/packages/react/src/context/config-context.tsx
@@ -2,12 +2,13 @@ import { Factor } from "@slashid/slashid";
 import { createContext, ReactNode, useMemo } from "react";
 import { TEXT, TextConfig } from "../components/text/constants";
 import { SlashID } from "../components/icon/slashid";
+import { FactorConfiguration } from "../domain/types";
 
 export type Logo = string | React.ReactNode;
 
 export interface IConfigurationContext {
   text: TextConfig;
-  factors: Factor[];
+  factors: FactorConfiguration[];
   logo: Logo;
   storeLastHandle: boolean;
   showBanner: boolean;

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -14,7 +14,7 @@ import {
   DynamicFlow,
 } from "./main";
 import { defaultOrganization } from "./middleware";
-import { Handle } from "./domain/types";
+import { FactorConfiguration, Handle } from "./domain/types";
 
 const rootOid = "b6f94b67-d20f-7fc3-51df-bf6e3b82683e";
 
@@ -30,7 +30,7 @@ const initialFactors: Factor[] = [
   },
 ];
 
-const withWan: Factor[] = [
+const withWan: FactorConfiguration[] = [
   { method: "webauthn", options: { attachment: "platform" } },
   { method: "email_link" },
   { method: "otp_via_sms" },
@@ -39,6 +39,14 @@ const withWan: Factor[] = [
     options: {
       provider: "google",
       client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID,
+    },
+  },
+  {
+    method: "oidc",
+    label: "Google SSO - label test",
+    options: {
+      provider: "google",
+      client_id: "TEST",
     },
   },
 ];
@@ -64,10 +72,7 @@ function Config() {
   }, []);
 
   return (
-    <ConfigurationProvider
-      factors={factors}
-      storeLastHandle={true}
-    >
+    <ConfigurationProvider factors={factors} storeLastHandle={true}>
       {/* <div className="formWrapper">
         <MultiFactorAuth
           steps={[

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -13,20 +13,43 @@ export interface LoginConfiguration {
 }
 
 export interface LoginMiddlewareContext {
-  user: User
-  sid: SlashID
+  user: User;
+  sid: SlashID;
 }
 
-export type LoginMiddleware = (context: LoginMiddlewareContext) => Promise<User>
+export type LoginMiddleware = (
+  context: LoginMiddlewareContext
+) => Promise<User>;
 
 export interface LoginOptions {
-  middleware?: LoginMiddleware | LoginMiddleware[]
+  middleware?: LoginMiddleware | LoginMiddleware[];
 }
 
 export type FactorOIDC = Extract<Factor, { method: "oidc" }>;
 
-export type LogIn = (config: LoginConfiguration, options?: LoginOptions) => Promise<User | undefined>;
-export type MFA = (config: LoginConfiguration, options?: LoginOptions) => Promise<User | undefined>;
+/**
+ * This makes it possible to add a label to the configured OIDC factors.
+ * This is useful when you want to change the default display (capitalized provider name).
+ */
+export type FactorLabeledOIDC = FactorOIDC & { label?: string };
+
+/**
+ * All factors that can be configured for usage in our UI components.
+ */
+export type FactorConfiguration =
+  | Exclude<Factor, FactorOIDC>
+  | FactorLabeledOIDC;
+
+export type LogIn = (
+  config: LoginConfiguration,
+  options?: LoginOptions
+) => Promise<User | undefined>;
+
+export type MFA = (
+  config: LoginConfiguration,
+  options?: LoginOptions
+) => Promise<User | undefined>;
+
 export type Retry = () => void;
 export type Cancel = () => void;
 


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-000)

A `label` can be optionally passed with the OIDC factor config.

There are two use cases we enable with this:
- multiple factors using the same provider (by default the SSO button will get the text content based on the provider name, resulting with duplicates - this way you choose what to display)
- SSO button text customization

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files