### PR TITLE
[SID-1214] add unstable/nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.4
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 16.14.0
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.14.0
           cache: "pnpm"
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org/"

--- a/.github/workflows/unstable-release.yml
+++ b/.github/workflows/unstable-release.yml
@@ -11,9 +11,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.4
+
+      - name: Use Node.js 16.14.0
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.0
+          cache: "pnpm"
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org/"
+
+      - name: Install dependencies
+        run: pnpm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Generate unstable changeset
         run: pnpm changeset version --snapshot next
+        
       - name: Build packages
         run: pnpm build
+        
       - name: Publish unstable packages
         run: pnpm changeset publish --tag next

--- a/.github/workflows/unstable-release.yml
+++ b/.github/workflows/unstable-release.yml
@@ -1,0 +1,19 @@
+name: Unstable/nightly release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  unstable-release:
+    name: Unstable/nightly release
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.4
+      - name: Generate unstable changeset
+        run: pnpm changeset version --snapshot next
+      - name: Build packages
+        run: pnpm build
+      - name: Publish unstable packages
+        run: pnpm changeset publish --tag next


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1214)

We want a low friction way to test new sdk versions before they're public.

Each time a changeset is merged to main we should publish a snapshot with a invalid semver version behind the `@next` tag

Changeset `--snapshot` generates a version like this: `0.0.0-next-20230825102611`

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files