### PR TITLE
[SID-1196] Improve GDPRConsentDialog usability

### DIFF
--- a/.changeset/pretty-chairs-help.md
+++ b/.changeset/pretty-chairs-help.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Improve GDPRConsentDialog usability

--- a/packages/react/src/components/dialog/index.tsx
+++ b/packages/react/src/components/dialog/index.tsx
@@ -1,10 +1,10 @@
 import * as RadixDialog from "@radix-ui/react-dialog";
 import { clsx } from "clsx";
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 import { Close } from "../icon/close";
 import * as styles from "./style.css";
 
-type Props = {
+export type DialogProps = {
   /** Dialog content */
   children: ReactNode;
   /** Dialog trigger */
@@ -16,7 +16,7 @@ type Props = {
   /** Dialog icon */
   icon?: ReactNode;
   /** Dialog custom portal container */
-  container?: HTMLElement;
+  container?: HTMLElement | (() => HTMLElement | null) | null;
   /** Dialog content container class name */
   className?: string;
   /** When this boolean is set to `false`, the close button is hidden and dialog cannot be closed by clicking on the overlay */
@@ -42,18 +42,33 @@ export const Dialog = ({
   container,
   dismissable = true,
   modal = true,
-}: Props) => {
+}: DialogProps) => {
+  /**
+   * Check if the container function return value changed every cycle but only
+   * trigger another render when it actually changes.
+   */
+  const containerFuncReturn = (() => {
+    if (typeof container !== "function") return null
+
+    return container()
+  })()
+
+  const __container = useMemo(() => {
+    if (typeof container === "function") return containerFuncReturn
+    return container
+  }, [container, containerFuncReturn])
+
   if (!trigger) return null;
 
   return (
     <RadixDialog.Root modal={modal} open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Trigger asChild>{trigger}</RadixDialog.Trigger>
-      <RadixDialog.Portal container={container}>
+      <RadixDialog.Portal container={__container}>
         {modal && <RadixDialog.Overlay className={styles.overlay} />}
         <RadixDialog.Content
           className={clsx("sid-dialog", styles.wrapper, className)}
           onInteractOutside={(e) => {
-            if (!dismissable) {
+            if (!modal || !dismissable) {
               e.preventDefault();
             }
           }}

--- a/packages/react/src/components/dialog/index.tsx
+++ b/packages/react/src/components/dialog/index.tsx
@@ -1,6 +1,6 @@
 import * as RadixDialog from "@radix-ui/react-dialog";
 import { clsx } from "clsx";
-import { ReactNode, useMemo } from "react";
+import { ReactNode } from "react";
 import { Close } from "../icon/close";
 import * as styles from "./style.css";
 
@@ -43,27 +43,12 @@ export const Dialog = ({
   dismissable = true,
   modal = true,
 }: DialogProps) => {
-  /**
-   * Check if the container function return value changed every cycle but only
-   * trigger another render when it actually changes.
-   */
-  const containerFuncReturn = (() => {
-    if (typeof container !== "function") return null
-
-    return container()
-  })()
-
-  const __container = useMemo(() => {
-    if (typeof container === "function") return containerFuncReturn
-    return container
-  }, [container, containerFuncReturn])
-
   if (!trigger) return null;
 
   return (
     <RadixDialog.Root modal={modal} open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Trigger asChild>{trigger}</RadixDialog.Trigger>
-      <RadixDialog.Portal container={__container}>
+      <RadixDialog.Portal container={typeof container === "function" ? container() : container}>
         {modal && <RadixDialog.Overlay className={styles.overlay} />}
         <RadixDialog.Content
           className={clsx("sid-dialog", styles.wrapper, className)}

--- a/packages/react/src/components/gdpr-consent-dialog/consent-dialog.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/consent-dialog.tsx
@@ -1,10 +1,10 @@
 import { GDPRConsent } from "@slashid/slashid";
 import { clsx } from "clsx";
-import { forwardRef, useEffect, useMemo, useReducer } from "react";
+import { useEffect, useMemo, useReducer } from "react";
 import { publicVariables } from "../../theme/theme.css";
-import { Button } from "../button";
 import { Dialog } from "../dialog";
 import { Cookie } from "../icon/cookie";
+import { TriggerButton } from './trigger-button'
 import { Text } from "../text";
 import { Actions } from "./actions";
 import { CONSENT_LEVELS_WITHOUT_NONE } from "./constants";
@@ -16,7 +16,6 @@ import {
   GDPRConsentDialogProps,
   UpdateGdprConsent,
 } from "./types";
-import { Teleport } from "../teleport";
 
 type Props = GDPRConsentDialogProps & {
   consents: GDPRConsent[];
@@ -69,25 +68,6 @@ export const ConsentDialog = ({
     }
   }, [open]);
 
-  const TriggerButton = forwardRef<HTMLButtonElement>((props, ref) => (
-    <Teleport to="sid-cookie-button">
-      <Button
-        {...props}
-        ref={ref}
-        testId="sid-gdpr-consent-dialog-trigger"
-        variant="neutralMd"
-        className={clsx(
-          "sid-gdpr-consent-dialog-trigger",
-          styles.dialogTrigger,
-          triggerClassName
-        )}
-      >
-        <Cookie />
-      </Button>
-    </Teleport>
-  ))
-  TriggerButton.displayName = "TriggerButton"
-
   return (
     <Dialog
       className={clsx("sid-gdpr-consent-dialog", styles.dialog, className)}
@@ -99,7 +79,9 @@ export const ConsentDialog = ({
         dispatch({ type: "SET_OPEN", payload: open })
       }
       trigger={
-        <TriggerButton />
+        <TriggerButton
+          buttonClassName={triggerClassName}
+        />
       }
       icon={<Cookie fill={publicVariables.color.primary} />}
     >

--- a/packages/react/src/components/gdpr-consent-dialog/consent-dialog.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/consent-dialog.tsx
@@ -1,6 +1,6 @@
 import { GDPRConsent } from "@slashid/slashid";
 import { clsx } from "clsx";
-import { useEffect, useMemo, useReducer } from "react";
+import { forwardRef, useEffect, useMemo, useReducer } from "react";
 import { publicVariables } from "../../theme/theme.css";
 import { Button } from "../button";
 import { Dialog } from "../dialog";
@@ -16,6 +16,7 @@ import {
   GDPRConsentDialogProps,
   UpdateGdprConsent,
 } from "./types";
+import { Teleport } from "../teleport";
 
 type Props = GDPRConsentDialogProps & {
   consents: GDPRConsent[];
@@ -68,6 +69,25 @@ export const ConsentDialog = ({
     }
   }, [open]);
 
+  const TriggerButton = forwardRef<HTMLButtonElement>((props, ref) => (
+    <Teleport to="sid-cookie-button">
+      <Button
+        {...props}
+        ref={ref}
+        testId="sid-gdpr-consent-dialog-trigger"
+        variant="neutralMd"
+        className={clsx(
+          "sid-gdpr-consent-dialog-trigger",
+          styles.dialogTrigger,
+          triggerClassName
+        )}
+      >
+        <Cookie />
+      </Button>
+    </Teleport>
+  ))
+  TriggerButton.displayName = "TriggerButton"
+
   return (
     <Dialog
       className={clsx("sid-gdpr-consent-dialog", styles.dialog, className)}
@@ -79,17 +99,7 @@ export const ConsentDialog = ({
         dispatch({ type: "SET_OPEN", payload: open })
       }
       trigger={
-        <Button
-          testId="sid-gdpr-consent-dialog-trigger"
-          variant="neutralMd"
-          className={clsx(
-            "sid-gdpr-consent-dialog-trigger",
-            styles.dialogTrigger,
-            triggerClassName
-          )}
-        >
-          <Cookie />
-        </Button>
+        <TriggerButton />
       }
       icon={<Cookie fill={publicVariables.color.primary} />}
     >

--- a/packages/react/src/components/gdpr-consent-dialog/gdpr-consent-dialog.test.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/gdpr-consent-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { GDPRConsent, GDPRConsentLevel, User } from "@slashid/slashid";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent, {
   PointerEventsCheckLevel,
 } from "@testing-library/user-event";
@@ -227,7 +227,12 @@ describe("#GDPRConsentDialog", () => {
       );
 
       await expectDialogToBeClosed();
-      await event.click(screen.getByTestId("sid-gdpr-consent-dialog-trigger"));
+
+      fireEvent(
+        screen.getByTestId("sid-gdpr-consent-dialog-trigger"),
+        new MouseEvent('click', { bubbles: true })
+      )
+      
       await expectDialogToBeOpenWithInitialState();
 
       await event.click(
@@ -373,7 +378,12 @@ describe("#GDPRConsentDialog", () => {
       );
 
       await expectDialogToBeClosed();
-      await event.click(screen.getByTestId("sid-gdpr-consent-dialog-trigger"));
+
+      fireEvent(
+        screen.getByTestId("sid-gdpr-consent-dialog-trigger"),
+        new MouseEvent('click', { bubbles: true })
+      )
+
       await expectDialogToBeOpenWithInitialState();
 
       await event.click(

--- a/packages/react/src/components/gdpr-consent-dialog/style.css.ts
+++ b/packages/react/src/components/gdpr-consent-dialog/style.css.ts
@@ -13,7 +13,7 @@ export const dialog = style({
   bottom: margin,
   right: margin,
   maxHeight: "542px",
-  maxWidth: "384px",
+  maxWidth: "400px",
   display: "grid",
   gridTemplateRows: "auto auto 1fr auto",
   backgroundColor: publicVariables.color.panel,

--- a/packages/react/src/components/gdpr-consent-dialog/trigger-button.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/trigger-button.tsx
@@ -1,0 +1,30 @@
+import React, { forwardRef } from 'react'
+import { Teleport } from '../teleport'
+import { Button } from '../button'
+import { clsx } from "clsx";
+import { Cookie } from "../icon/cookie";
+import * as styles from "./style.css";
+
+interface TriggerButtonProps {
+  buttonClassName?: string
+}
+
+export const TriggerButton = forwardRef<HTMLButtonElement, TriggerButtonProps>(({ buttonClassName, ...props }, ref) => (
+  <Teleport to="sid-cookie-button">
+    <Button
+      {...props}
+      ref={ref}
+      testId="sid-gdpr-consent-dialog-trigger"
+      variant="neutralMd"
+      className={clsx(
+        "sid-gdpr-consent-dialog-trigger",
+        styles.dialogTrigger,
+        buttonClassName
+      )}
+    >
+      <Cookie />
+    </Button>
+  </Teleport>
+))
+
+TriggerButton.displayName = "TriggerButton"

--- a/packages/react/src/components/gdpr-consent-dialog/types.ts
+++ b/packages/react/src/components/gdpr-consent-dialog/types.ts
@@ -1,5 +1,6 @@
 import { GDPRConsent, GDPRConsentLevel } from "@slashid/slashid";
 import { CONSENT_LEVELS_WITHOUT_NONE } from "./constants";
+import { type DialogProps } from "../dialog";
 
 export type ConsentSettingsLevel = (typeof CONSENT_LEVELS_WITHOUT_NONE)[number];
 export type ConsentSettings = Record<ConsentSettingsLevel, boolean>;
@@ -25,7 +26,7 @@ export type GDPRConsentDialogProps = {
   /** When this boolean is set to `true`, it forces the dialog to be open on page load regardless of if consent was given previously */
   forceOpen?: boolean;
   /** Custom portal container element that the dialog portals into */
-  container?: HTMLElement;
+  container?: DialogProps["container"];
   /** Callback when user actions are successful */
   onSuccess?: OnSuccess;
   /** Callback when user actions fail */

--- a/packages/react/src/components/teleport/index.tsx
+++ b/packages/react/src/components/teleport/index.tsx
@@ -9,7 +9,11 @@ export interface TeleportProps {
 }
 
 /**
- * Renders child content in a portal element at the DOM root
+ * A managed React portal. Creates and manages resolution of portal
+ * destination elements for you, just provide a name.
+ * 
+ * The portal destination elements are created at the DOM root and
+ * [children] are rendered here.
  * 
  * @param to The destination portal name
  * @param children The content to be teleported

--- a/packages/react/src/components/teleport/index.tsx
+++ b/packages/react/src/components/teleport/index.tsx
@@ -1,0 +1,26 @@
+import { createPortal } from "react-dom"
+import { findOrCreateTeleportTarget } from "./util"
+import { ReactNode } from "react"
+
+export interface TeleportProps {
+  to: string
+  children: ReactNode
+  renderKey?: string | null | undefined
+}
+
+/**
+ * Renders child content in a portal element at the DOM root
+ * 
+ * @param to The destination portal name
+ * @param children The content to be teleported
+ * @param renderKey (optional) A key to control when the content rerenders
+ */
+export const Teleport = ({ to, children, renderKey }: TeleportProps) => {
+  const target = findOrCreateTeleportTarget(to)
+
+  return (
+    <>
+      {createPortal(children, target, renderKey)}
+    </>
+  )
+}

--- a/packages/react/src/components/teleport/util.ts
+++ b/packages/react/src/components/teleport/util.ts
@@ -7,7 +7,7 @@
  * 
  * @param teleportKey the key of teleport target
  * 
- * @returns DOM selector for teleport target i.e. #foo
+ * @returns the portal element
  */
 export const findOrCreateTeleportTarget = (teleportKey: string): HTMLElement => {
   const element = globalThis.document.getElementById(teleportKey)

--- a/packages/react/src/components/teleport/util.ts
+++ b/packages/react/src/components/teleport/util.ts
@@ -1,0 +1,23 @@
+/**
+ * Companion utility for <Teleport />
+ * 
+ * Searches the DOM for a teleport target element
+ * with id [teleportId]. If none is found, creates
+ * one at the root of the DOM.
+ * 
+ * @param teleportKey the key of teleport target
+ * 
+ * @returns DOM selector for teleport target i.e. #foo
+ */
+export const findOrCreateTeleportTarget = (teleportKey: string): HTMLElement => {
+  const element = globalThis.document.getElementById(teleportKey)
+  const targetExists = (element !== null)
+
+  if (targetExists) return element
+
+  const teleport = document.createElement('div')
+  teleport.id = teleportKey
+  document.body.appendChild(teleport)
+
+  return teleport
+}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1196)

I encountered some issues trying to implement the component in my test bench.

### Issues
1. Implementing the `container` prop is quite clunky, and the prop doesn't have parity with the `mui/modal` implementation which was the reference
2. Dismiss behaviour not as expected, dismiss by clicking background should only happen in modal mode
3. The advanced mode ("Customize") has truncated buttons because the element isn't wide enough
4. The cookie button does not appear in the portal, so it still suffers the same problem as the dialog did before

### Changes
- `<Dialog />`
    - Improve the `container` prop API, bringing it into parity with `mui/modal`
        - The main improvement here is allowing an (internally cached) getter function for locating the original DOM node, otherwise a lot of complicated boilerplate is delegated to the user.
    -  Component can no longer by dismissed in "dialog mode" by clicking outside the element
        - Dismiss by clicking outside the element is permanently disabled for dialogs i.e. `<Dialog modal={false} />`
        - Dismiss by clicking outside the element is reserved for modals i.e. `<Dialog modal dismissable />` (the default)
        - Dismiss by clicking outside the element can be disabled **for modals only** i.e. `<Dialog modal dismissable={false} />`
- Add `<Teleport />`
    - **Internal use only**
    - This component is a fascade for `React.createPortal()` with a simpler API.
- `<GDPRConsentDialog />`
    - Component is a little wider to allow for all three buttons in the advanced mode
    - The cookie button (shown when the dialog is dismissed) will now render in its own portal, seperate to the dialog content.
        - Without this change the button renders in the tree where the component is mounted, same problem we had before with the dialog itself.
        - I considered putting the button in `<RadixDialog.Portal />` but there is implicit behaviour here where the portal is only shown when `<RadixDialog.Root open={true} />` which is an issue, because this button is only shown when `open=false`.
        - Given all that context, the button is now mounted inside a `<Teleport />` at the document root

#### Examples
Improved `container` prop
```tsx
// now possible

<GDPRConsent
  container={() => document.getElementById("foo")}
/>
```

Teleport
```tsx
<Teleport to="some-name">
  // ...
</Teleport>
```
## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files