### PR TITLE
[SID-1214] Generate npmrc before publish

### DIFF
--- a/.github/workflows/unstable-release.yml
+++ b/.github/workflows/unstable-release.yml
@@ -1,4 +1,4 @@
-name: Unstable/nightly release
+name: Unstable/next release
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unstable-release:
-    name: Unstable/nightly release
+    name: Unstable/next release
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -30,6 +30,9 @@ jobs:
         
       - name: Build packages
         run: pnpm build
-        
+
+      - name: Setup npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
       - name: Publish unstable packages
         run: pnpm changeset publish --tag next


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1214)

Unstable publish [failed](https://github.com/slashid/javascript/actions/runs/6013643387/job/16311531987) because of missing npm token

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files