### PR TITLE
[SID-1231] Improve dropdown spacing

### DIFF
--- a/packages/react/src/components/dropdown/dropdown.css.ts
+++ b/packages/react/src/components/dropdown/dropdown.css.ts
@@ -16,6 +16,8 @@ export const trigger = style({
   border: `1px solid ${publicVariables.color.subtle}`,
   borderRadius: publicVariables.border.radius,
   fontFamily: publicVariables.font.fontFamily,
+  position: "relative",
+  textAlign: "left",
 
   ":active": {
     border: `1px solid ${publicVariables.color.tertiary}`,
@@ -43,8 +45,8 @@ export const input = style({
   fontSize: theme.font.size.base,
   fontWeight: theme.font.weight.semibold,
   color: publicVariables.color.foreground,
-  display: "flex",
-  justifyContent: "space-between",
+  display: "grid",
+  gridTemplateColumns: "auto 24px"
 });
 
 export const content = style({
@@ -69,7 +71,8 @@ export const item = style({
   borderRadius: "12px",
   padding: "16px 12px",
   display: "flex",
-  justifyContent: "space-between",
+  columnGap: "8px",
+  alignItems: "center",
 
   ":hover": {
     backgroundColor: publicVariables.color.soft,
@@ -80,7 +83,13 @@ export const item = style({
 });
 
 export const icon = style({
-  position: "relative",
-  top: "-8px",
-  zIndex: 0,
+  position: "absolute",
+  right: "16px",
+  zIndex: 0
 });
+
+export const selectedIcon = style({
+  height: "16px",
+  marginLeft: "auto",
+  justifySelf: "flex-end"
+})

--- a/packages/react/src/components/dropdown/index.tsx
+++ b/packages/react/src/components/dropdown/index.tsx
@@ -57,10 +57,10 @@ export const Dropdown: React.FC<Props> = ({
             placeholder={placeholder}
           >
             <Select.Value />
-            <ChevronDown
-              className={clsx("sid-dropdown__trigger__icon", styles.icon)}
-            />
           </div>
+          <ChevronDown
+            className={clsx("sid-dropdown__trigger__icon", styles.icon)}
+          />
         </Select.Trigger>
 
         <Select.Content
@@ -81,7 +81,7 @@ export const Dropdown: React.FC<Props> = ({
                   value={item.value}
                 >
                   <Select.ItemText>{item.label}</Select.ItemText>
-                  <Select.ItemIndicator>
+                  <Select.ItemIndicator className={styles.selectedIcon}>
                     <Check className="sid-dropdown__item--selected__icon" />
                   </Select.ItemIndicator>
                 </Select.Item>


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1231)

Very small CSS change - the spacing in this component between text and icon don't look very professional

Before:
![image](https://github.com/slashid/javascript/assets/139138253/bf176dbf-3f48-437c-b2e2-626ef1b95d13)

After:
![image](https://github.com/slashid/javascript/assets/139138253/207f3fe8-db6d-40eb-8c27-196dace36668)

Before:
![image](https://github.com/slashid/javascript/assets/139138253/5f112f1f-551c-44b3-8a20-3447a61db9dd)

After:
![image](https://github.com/slashid/javascript/assets/139138253/d9a37f16-7159-4fbd-8e60-5bb8a19ffd4e)