### PR TITLE
[SID-1233] Add inline docs for the GDPR hook

### DIFF
--- a/.changeset/sweet-rice-call.md
+++ b/.changeset/sweet-rice-call.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Use a consistent naming strategy with uppercase acronyms

--- a/packages/react/src/components/gdpr-consent-dialog/index.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/index.tsx
@@ -1,4 +1,4 @@
-import { useGdprConsent } from "../../hooks/use-gdpr-consent";
+import { useGDPRConsent } from "../../hooks/use-gdpr-consent";
 import { SlashIDLoaded } from "../slashid-loaded";
 import { ConsentDialog } from "./consent-dialog";
 import { GDPRConsentDialogProps } from "./types";
@@ -7,7 +7,7 @@ import { GDPRConsentDialogProps } from "./types";
  * GDPR Consent Dialog component to manage the GDPR consent levels for the current user.
  */
 export const GDPRConsentDialog = (props: GDPRConsentDialogProps) => {
-  const { consents, consentState, updateGdprConsent } = useGdprConsent();
+  const { consents, consentState, updateGdprConsent } = useGDPRConsent();
 
   if (consentState === "initial") {
     return null;

--- a/packages/react/src/components/gdpr-consent-dialog/index.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/index.tsx
@@ -7,9 +7,9 @@ import { GDPRConsentDialogProps } from "./types";
  * GDPR Consent Dialog component to manage the GDPR consent levels for the current user.
  */
 export const GDPRConsentDialog = (props: GDPRConsentDialogProps) => {
-  const { consents, consentState, updateGdprConsent } = useGDPRConsent();
+  const { consents, state, updateGdprConsent } = useGDPRConsent();
 
-  if (consentState === "initial") {
+  if (state === "initial") {
     return null;
   }
 

--- a/packages/react/src/hooks/use-gdpr-consent.test.tsx
+++ b/packages/react/src/hooks/use-gdpr-consent.test.tsx
@@ -2,12 +2,12 @@ import { GDPRConsent, GDPRConsentLevel, User } from "@slashid/slashid";
 import { render, screen } from "@testing-library/react";
 import { createTestUser } from "../components/test-utils";
 import { TestSlashIDProvider } from "../context/test-slash-id-provider";
-import { STORAGE_GDPR_CONSENT_KEY, useGdprConsent } from "./use-gdpr-consent";
+import { STORAGE_GDPR_CONSENT_KEY, useGDPRConsent } from "./use-gdpr-consent";
 
 const NO_CONSENTS_TEXT = "No consents";
 
 const TestComponent = () => {
-  const { consents } = useGdprConsent();
+  const { consents } = useGDPRConsent();
 
   if (consents.length === 0) {
     return <div>{NO_CONSENTS_TEXT}</div>;

--- a/packages/react/src/hooks/use-gdpr-consent.ts
+++ b/packages/react/src/hooks/use-gdpr-consent.ts
@@ -80,6 +80,16 @@ type UseGdprConsent = () => {
   deleteGdprConsent: () => Promise<void>;
 };
 
+/**
+ * A stateful hook providing access to the current user's GDPR consent levels.
+ * Use this hook to list the accepted levels and accept and reject additional levels.
+ *
+ * If there is no authenticated user, the consent levels will be stored in local storage.
+ * Otherwise, the consent levels will be stored using the SlashID API.
+ *
+ *
+ * @returns {UseGdprConsent} an object with the current consent levels and methods to update it
+ */
 export const useGdprConsent: UseGdprConsent = () => {
   const { user, sdkState, sid } = useSlashID();
   const [consents, setConsents] = useState<GDPRConsent[]>([]);

--- a/packages/react/src/hooks/use-gdpr-consent.ts
+++ b/packages/react/src/hooks/use-gdpr-consent.ts
@@ -71,7 +71,7 @@ export const createApiGDPRConsentStorage = (
 
 type ConsentState = "initial" | "ready";
 
-type UseGdprConsent = () => {
+type UseGDPRConsent = () => {
   consents: GDPRConsent[];
   consentState: ConsentState;
   updateGdprConsent: (
@@ -87,10 +87,9 @@ type UseGdprConsent = () => {
  * If there is no authenticated user, the consent levels will be stored in local storage.
  * Otherwise, the consent levels will be stored using the SlashID API.
  *
- *
- * @returns {UseGdprConsent} an object with the current consent levels and methods to update it
+ * @returns {UseGDPRConsent} an object with the current consent levels and methods to update it
  */
-export const useGdprConsent: UseGdprConsent = () => {
+export const useGDPRConsent: UseGDPRConsent = () => {
   const { user, sdkState, sid } = useSlashID();
   const [consents, setConsents] = useState<GDPRConsent[]>([]);
   const [consentState, setConsentState] = useState<ConsentState>("initial");

--- a/packages/react/src/hooks/use-gdpr-consent.ts
+++ b/packages/react/src/hooks/use-gdpr-consent.ts
@@ -73,7 +73,7 @@ type ConsentState = "initial" | "ready";
 
 type UseGDPRConsent = () => {
   consents: GDPRConsent[];
-  consentState: ConsentState;
+  state: ConsentState;
   updateGdprConsent: (
     consentLevels: GDPRConsentLevel[]
   ) => Promise<GDPRConsent[]>;
@@ -144,5 +144,5 @@ export const useGDPRConsent: UseGDPRConsent = () => {
     setConsents([]);
   }, [storage]);
 
-  return { consents, consentState, updateGdprConsent, deleteGdprConsent };
+  return { consents, state: consentState, updateGdprConsent, deleteGdprConsent };
 };

--- a/packages/react/src/main.ts
+++ b/packages/react/src/main.ts
@@ -13,7 +13,7 @@ import {
   ConfigurationProvider,
 } from "./context/config-context";
 import { SlashIDContext, SlashIDProvider } from "./context/slash-id-context";
-import { useGdprConsent } from "./hooks/use-gdpr-consent";
+import { useGDPRConsent } from "./hooks/use-gdpr-consent";
 import { useOrganizations } from "./hooks/use-organizations";
 import { useSlashID } from "./hooks/use-slash-id";
 import {
@@ -40,7 +40,7 @@ export {
   SlashIDLoaded,
   SlashIDProvider,
   StepUpAuth,
-  useGdprConsent,
+  useGDPRConsent,
   useOrganizations,
   useSlashID,
 


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1233)

We expose the `useGdprConsent` hook without any inline docs - fixed with this PR.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files