### PR TITLE
[SID-1233] Refactor consent state

### DIFF
--- a/.changeset/two-spies-stare.md
+++ b/.changeset/two-spies-stare.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Refactored the hook to expose isLoading instead of the state variable

--- a/packages/react/src/components/gdpr-consent-dialog/index.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/index.tsx
@@ -7,9 +7,9 @@ import { GDPRConsentDialogProps } from "./types";
  * GDPR Consent Dialog component to manage the GDPR consent levels for the current user.
  */
 export const GDPRConsentDialog = (props: GDPRConsentDialogProps) => {
-  const { consents, state, updateGdprConsent } = useGDPRConsent();
+  const { consents, isLoading, updateGdprConsent } = useGDPRConsent();
 
-  if (state === "initial") {
+  if (isLoading) {
     return null;
   }
 

--- a/packages/react/src/hooks/use-gdpr-consent.ts
+++ b/packages/react/src/hooks/use-gdpr-consent.ts
@@ -73,7 +73,7 @@ type ConsentState = "initial" | "ready";
 
 type UseGDPRConsent = () => {
   consents: GDPRConsent[];
-  state: ConsentState;
+  isLoading: boolean;
   updateGdprConsent: (
     consentLevels: GDPRConsentLevel[]
   ) => Promise<GDPRConsent[]>;
@@ -144,5 +144,10 @@ export const useGDPRConsent: UseGDPRConsent = () => {
     setConsents([]);
   }, [storage]);
 
-  return { consents, state: consentState, updateGdprConsent, deleteGdprConsent };
+  return {
+    consents,
+    isLoading: consentState === "initial",
+    updateGdprConsent,
+    deleteGdprConsent,
+  };
 };


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1233)

Use `isLoading` instead of exposing internal state.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files