### PR TITLE
[SID-1239] GDPR: when necessaryCookiesRequired is set to false, enable the toggle for that level

### DIFF
--- a/.changeset/khaki-cups-deny.md
+++ b/.changeset/khaki-cups-deny.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Adjust requireNecessaryCookies prop to behave as in the docs

--- a/packages/react/src/components/gdpr-consent-dialog/consent-dialog.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/consent-dialog.tsx
@@ -126,6 +126,7 @@ export const ConsentDialog = ({
           {isCustomizing && (
             <Settings
               consentSettings={consentSettings}
+              necessaryCookiesRequired={necessaryCookiesRequired}
               toggleConsent={(level) =>
                 dispatch({ type: "TOGGLE_CONSENT", payload: level })
               }

--- a/packages/react/src/components/gdpr-consent-dialog/gdpr-consent-dialog.test.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/gdpr-consent-dialog.test.tsx
@@ -63,9 +63,6 @@ const expectDialogToBeOpenWithCustomizingState = async (
     ).toBeInTheDocument();
 
     expect(
-      screen.getByTestId("sid-gdpr-consent-switch-necessary")
-    ).toHaveAttribute("data-blocked", "true");
-    expect(
       screen.getByTestId(`sid-gdpr-consent-switch-${level}`)
     ).toHaveAttribute("data-state", isChecked ? "checked" : "unchecked");
   });
@@ -124,6 +121,60 @@ describe("#GDPRConsentDialog", () => {
     setItemSpy.mockClear();
     getGDPRConsentSpy.mockClear();
     setGDPRConsentSpy.mockClear();
+  });
+
+  describe("general features", () => {
+    test("should allow toggling the necessary consent in the customize state when necessaryCookiesRequired is false", async () => {
+      render(
+        <TestSlashIDProvider sdkState="ready">
+          <GDPRConsentDialog necessaryCookiesRequired={false} />
+        </TestSlashIDProvider>
+      );
+
+      await expectDialogToBeOpenWithInitialState();
+
+      await event.click(
+        screen.getByTestId("sid-gdpr-consent-dialog-customize")
+      );
+
+      expect(
+        screen.getByTestId("sid-gdpr-consent-switch-necessary")
+      ).toHaveAttribute("data-blocked", "false");
+
+      expect(
+        screen.getByTestId("sid-gdpr-consent-switch-necessary")
+      ).toHaveAttribute("data-state", "unchecked");
+
+      await event.click(
+        screen.getByTestId("sid-gdpr-consent-switch-necessary")
+      );
+
+      expect(
+        screen.getByTestId("sid-gdpr-consent-switch-necessary")
+      ).toHaveAttribute("data-state", "checked");
+    });
+
+    test("should block toggling the necessary consent in the customize state when necessaryCookiesRequired is true", async () => {
+      render(
+        <TestSlashIDProvider sdkState="ready">
+          <GDPRConsentDialog necessaryCookiesRequired />
+        </TestSlashIDProvider>
+      );
+
+      await expectDialogToBeOpenWithInitialState();
+
+      await event.click(
+        screen.getByTestId("sid-gdpr-consent-dialog-customize")
+      );
+
+      expect(
+        screen.getByTestId("sid-gdpr-consent-switch-necessary")
+      ).toHaveAttribute("data-blocked", "true");
+
+      expect(
+        screen.getByTestId("sid-gdpr-consent-switch-necessary")
+      ).toHaveAttribute("data-state", "checked");
+    });
   });
 
   describe("anonymous user", () => {
@@ -230,9 +281,9 @@ describe("#GDPRConsentDialog", () => {
 
       fireEvent(
         screen.getByTestId("sid-gdpr-consent-dialog-trigger"),
-        new MouseEvent('click', { bubbles: true })
-      )
-      
+        new MouseEvent("click", { bubbles: true })
+      );
+
       await expectDialogToBeOpenWithInitialState();
 
       await event.click(
@@ -381,8 +432,8 @@ describe("#GDPRConsentDialog", () => {
 
       fireEvent(
         screen.getByTestId("sid-gdpr-consent-dialog-trigger"),
-        new MouseEvent('click', { bubbles: true })
-      )
+        new MouseEvent("click", { bubbles: true })
+      );
 
       await expectDialogToBeOpenWithInitialState();
 

--- a/packages/react/src/components/gdpr-consent-dialog/settings.tsx
+++ b/packages/react/src/components/gdpr-consent-dialog/settings.tsx
@@ -3,16 +3,22 @@ import { Switch } from "../switch";
 import { Text } from "../text";
 import { CONSENT_LEVELS_WITHOUT_NONE } from "./constants";
 import * as styles from "./style.css";
-import { ConsentSettings, ConsentSettingsLevel } from "./types";
+import {
+  ConsentSettings,
+  ConsentSettingsLevel,
+  GDPRConsentDialogProps,
+} from "./types";
 
 type Props = {
   consentSettings: ConsentSettings;
+  necessaryCookiesRequired?: GDPRConsentDialogProps["necessaryCookiesRequired"];
   toggleConsent: (level: ConsentSettingsLevel) => void;
   disabled?: boolean;
 };
 
 export const Settings = ({
   consentSettings,
+  necessaryCookiesRequired = false,
   toggleConsent,
   disabled = false,
 }: Props) => {
@@ -24,7 +30,7 @@ export const Settings = ({
         icon: (
           <Switch
             data-testid={`sid-gdpr-consent-switch-${level}`}
-            blocked={level === "necessary"}
+            blocked={level === "necessary" && necessaryCookiesRequired}
             disabled={disabled}
             checked={consentSettings[level]}
             onCheckedChange={() => toggleConsent(level)}

--- a/packages/react/src/components/gdpr-consent-dialog/types.ts
+++ b/packages/react/src/components/gdpr-consent-dialog/types.ts
@@ -16,7 +16,7 @@ export type GDPRConsentDialogProps = {
   className?: string;
   /** Custom class name for the trigger button */
   triggerClassName?: string;
-  /** Value of the lock on the necessary cookies category */
+  /** Prevent rejecting the necessary consent level when customizing consent levels */
   necessaryCookiesRequired?: boolean;
   /** Default consent levels to store when clicking on accept all */
   defaultAcceptAllLevels?: ConsentSettingsLevel[];


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1239)

`necessaryCookiesRequired` should behave this way:
- when `true` it should render a lock instead of a toggle for the corresponding level and be accepted by default
- when `false` (default) the toggle for `necessary` should behave as any other toggle

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have generated the new version of the docs website and smoke tested it
- [x] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have updated the README and DEVELOPMENT files