### PR TITLE
[Issue-154] Fix the color and font-weight in the <Form> component

### DIFF
--- a/packages/react/src/components/dynamic-flow/initial.tsx
+++ b/packages/react/src/components/dynamic-flow/initial.tsx
@@ -35,10 +35,14 @@ export const Initial = ({ flowState, handleSubmit, middleware }: Props) => {
       <div className={styles.header}>
         <Text
           as="h1"
-          variant={{ size: "2xl-title", weight: "bold" }}
           t="initial.title"
+          variant={{ size: "2xl-title", weight: "bold" }}
         />
-        <Text variant={{ color: "tertiary" }} as="h2" t="initial.subtitle" />
+        <Text
+          as="h2"
+          t="initial.subtitle"
+          variant={{ color: "contrast", weight: "semibold" }}
+        />
       </div>
       <FormProvider>
         <ConfiguredHandleForm handleSubmit={handleSubmit} />

--- a/packages/react/src/components/form/authenticating.tsx
+++ b/packages/react/src/components/form/authenticating.tsx
@@ -100,14 +100,14 @@ export const Authenticating: React.FC<Props> = ({ flowState }) => {
       >
         {text["authenticating.back"]}
       </LinkButton>
-      <Text as="h1" t={title} variant={{ size: "2xl-title" }}>
+      <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }}>
         {factor.method === "oidc" ? (
           <span className={styles.oidcTitle}>
             {factor.options?.provider as unknown as string}
           </span>
         ) : undefined}
       </Text>
-      <Text t={message} variant={{ color: "contrast" }} />
+      <Text t={message} variant={{ color: "contrast", weight: "semibold" }} />
       {isFactorOTP(factor) ? <OtpForm /> : <Loader />}
       <div className={styles.retryPrompt}>
         <Text

--- a/packages/react/src/components/form/error.tsx
+++ b/packages/react/src/components/form/error.tsx
@@ -37,8 +37,16 @@ export const Error: React.FC<Props> = ({ flowState }) => {
       >
         {text["authenticating.back"]}
       </LinkButton>
-      <Text as="h1" t="error.title" variant={{ size: "2xl-title" }} />
-      <Text as="h2" t="error.subtitle" variant={{ color: "contrast" }} />
+      <Text
+        as="h1"
+        t="error.title"
+        variant={{ size: "2xl-title", weight: "bold" }}
+      />
+      <Text
+        as="h2"
+        t="error.subtitle"
+        variant={{ color: "contrast", weight: "semibold" }}
+      />
       <div
         className={clsx(styles.error, sprinkles({ marginY: "12" }), centered)}
       >

--- a/packages/react/src/components/form/initial/index.tsx
+++ b/packages/react/src/components/form/initial/index.tsx
@@ -49,10 +49,14 @@ export const Initial: React.FC<Props> = ({
       <div className={styles.header}>
         <Text
           as="h1"
-          variant={{ size: "2xl-title", weight: "bold" }}
           t="initial.title"
+          variant={{ size: "2xl-title", weight: "bold" }}
         />
-        <Text variant={{ color: "tertiary" }} as="h2" t="initial.subtitle" />
+        <Text
+          as="h2"
+          t="initial.subtitle"
+          variant={{ color: "contrast", weight: "semibold" }}
+        />
       </div>
       <ConfiguredHandleForm
         lastHandle={lastHandle}

--- a/packages/react/src/components/form/success.tsx
+++ b/packages/react/src/components/form/success.tsx
@@ -25,8 +25,16 @@ type Props = {
 export const Success: React.FC<Props> = () => {
   return (
     <article data-testid="sid-form-success-state">
-      <Text as="h1" t="success.title" variant={{ size: "2xl-title" }} />
-      <Text as="h2" t="success.subtitle" variant={{ color: "contrast" }} />
+      <Text
+        as="h1"
+        t="success.title"
+        variant={{ size: "2xl-title", weight: "bold" }}
+      />
+      <Text
+        as="h2"
+        t="success.subtitle"
+        variant={{ color: "contrast", weight: "semibold" }}
+      />
       <div
         className={clsx(styles.check, sprinkles({ marginY: "12" }), centered)}
       >


### PR DESCRIPTION
## Description

[Githubissue](https://github.com/slashid/javascript/issues/154)

Fix the color and font-weight in the `<Form>` component following Significa's last feedback:

1. [On the authenticating state and success/fail state of the signin/sign-up component, the fontweight of the title should be 700 (500 in the implementation).pdf](https://github.com/slashid/javascript/files/12600388/On.the.authenticating.state.and.success.fail.state.faf53b3c2dca41f0904b0175ad6622a8.pdf)
2. [On the sign-in/sign-up component, the color of the description should be “lightTheme/contrast” (in the implementation is “lightTheme/tertiary”).pdf](https://github.com/slashid/javascript/files/12600403/On.the.sign-in.sign-up.component.the.color.of.the.b7b6bbc318864a378e6efe9621918e61.pdf)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
