### PR TITLE
React SDK: bump core sdk peer dep to 3.14.0

### DIFF
--- a/.changeset/seven-tomatoes-hang.md
+++ b/.changeset/seven-tomatoes-hang.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Require @slashid/slashid@3.14.0 as peer

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "^3.13.2",
+    "@slashid/slashid": "^3.14.0",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -95,7 +95,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.13.2",
+    "@slashid/slashid": ">= 3.14.0",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ importers:
       '@radix-ui/react-select': ^1.1.2
       '@radix-ui/react-switch': ^1.0.3
       '@radix-ui/react-tabs': ^1.0.1
-      '@slashid/slashid': ^3.13.2
+      '@slashid/slashid': ^3.14.0
       '@storybook/addon-essentials': 7.0.0-rc.2
       '@storybook/addon-interactions': 7.4.0
       '@storybook/addon-links': 7.4.0
@@ -257,7 +257,7 @@ importers:
       country-list-with-dial-code-and-flag: 3.0.3
     devDependencies:
       '@faker-js/faker': 8.0.2
-      '@slashid/slashid': 3.13.2
+      '@slashid/slashid': 3.14.0
       '@storybook/addon-essentials': 7.0.0-rc.2_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-interactions': 7.4.0_zkisbtryv3xtasf42ecsrjh3ky
       '@storybook/addon-links': 7.4.0_biqbaboplfbrettd7655fr4n2y
@@ -5679,8 +5679,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid/3.13.2:
-    resolution: {integrity: sha512-/qIuZMRXZ70MI8lmCRYt1CQxpagGrzDSKX/soDTCCC5/r0O2boEnX6YCoMrmv9gxV4a68P7BAfH4gr9VncL1kg==}
+  /@slashid/slashid/3.14.0:
+    resolution: {integrity: sha512-4rPhosFdWro8HSWYwKHkPKlsSHV0CAmVNthMjuyiJ74Q3eXncxY6mYzIWiwovtxj3qbmUr3Q5LD0yqReu1wvjA==}
     dependencies:
       '@changesets/cli': 2.26.2
       '@types/uuid': 8.3.4


### PR DESCRIPTION
## Description

Upgrading to set requirement for [@slashid/slashid@3.14.0](https://github.com/slashid/ng-evangelion/pull/1038)
