### PR TITLE
Fix GDPR dialog close button outline and Login form icon position

### DIFF
--- a/.changeset/pretty-lobsters-lick.md
+++ b/.changeset/pretty-lobsters-lick.md
@@ -1,0 +1,6 @@
+---
+"@slashid/react": patch
+---
+
+Fix GDPR dialog close button outline
+Fix Login form icon position

--- a/packages/react/src/components/dialog/style.css.ts
+++ b/packages/react/src/components/dialog/style.css.ts
@@ -40,6 +40,8 @@ export const closeButton = style({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+  width: "16px",
+  height: "16px",
   borderRadius: "50%",
 
   ":hover": {

--- a/packages/react/src/components/spinner/circle.css.ts
+++ b/packages/react/src/components/spinner/circle.css.ts
@@ -164,4 +164,5 @@ export const innerCircleVariants = styleVariants({
 
 export const content = style({
   position: "absolute",
+  display: "inline-flex",
 });


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-000)

1. Fixed GDPR dialog close button outline.
2. Fixed Login form icon position.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have generated a `changeset` if my change affects the published packages
