### PR TITLE
[SID-1350] React SDK: improve error handling

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "^3.14.1",
+    "@slashid/slashid": "link:/Users/ivankovic/projects/slashid/ng-evangelion/web/sdk",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/src/components/form/error.tsx
+++ b/packages/react/src/components/form/error.tsx
@@ -1,5 +1,6 @@
 import { useConfiguration } from "../../hooks/use-configuration";
 import { sprinkles } from "../../theme/sprinkles.css";
+import { Button } from "../button";
 import { LinkButton } from "../button/link-button";
 import { Circle } from "../spinner/circle";
 import { Text } from "../text";
@@ -82,6 +83,14 @@ export const Error: React.FC<Props> = ({ flowState }) => {
         variant={{ color: "contrast", weight: "semibold" }}
       />
       <ErrorIcon />
+      <Button
+        type="submit"
+        variant="primary"
+        testId="sid-form-error-retry-button"
+        onClick={() => flowState.retry()}
+      >
+        {text["error.retry"]}
+      </Button>
     </article>
   );
 };

--- a/packages/react/src/components/form/error.tsx
+++ b/packages/react/src/components/form/error.tsx
@@ -73,7 +73,6 @@ type ErrorTemplateProps = {
 export const Error = ({ children }: ErrorTemplateProps) => {
   const { flowState } = useInternalFormContext();
 
-  console.log({ children, status: flowState?.status });
   if (flowState?.status !== "error") return null;
 
   if (typeof children === "function") {

--- a/packages/react/src/components/form/error.tsx
+++ b/packages/react/src/components/form/error.tsx
@@ -3,7 +3,9 @@ import { sprinkles } from "../../theme/sprinkles.css";
 import { LinkButton } from "../button/link-button";
 import { Circle } from "../spinner/circle";
 import { Text } from "../text";
+import { TextConfigKey } from "../text/constants";
 import { ErrorState } from "./flow";
+import { errors } from "@slashid/slashid";
 
 const ErrorIcon = () => (
   <Circle variant="red" shouldAnimate={false}>
@@ -28,12 +30,36 @@ const ErrorIcon = () => (
   </Circle>
 );
 
+type ErrorType = "response" | "rateLimit" | "unknown";
+
+function getErrorType(error: Error): ErrorType {
+  if (errors.isResponseError(error)) {
+    return "response";
+  }
+
+  if (errors.isRateLimitError(error)) {
+    return "rateLimit";
+  }
+
+  return "unknown";
+}
+
+function mapErrorTypeToText(errorType: ErrorType): TextConfigKey {
+  switch (errorType) {
+    case "rateLimit":
+      return "error.subtitle.rateLimit";
+    default:
+      return "error.subtitle";
+  }
+}
+
 type Props = {
   flowState: ErrorState;
 };
 
 export const Error: React.FC<Props> = ({ flowState }) => {
   const { text } = useConfiguration();
+  const errorType = getErrorType(flowState.context.error);
 
   return (
     <article data-testid="sid-form-error-state">
@@ -52,7 +78,7 @@ export const Error: React.FC<Props> = ({ flowState }) => {
       />
       <Text
         as="h2"
-        t="error.subtitle"
+        t={mapErrorTypeToText(errorType)}
         variant={{ color: "contrast", weight: "semibold" }}
       />
       <ErrorIcon />

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -97,12 +97,19 @@ export const Form = ({
         ) : undefined,
       success:
         status === "success" ? <Success flowState={flowState} /> : undefined,
-      error: status === "error" ? <Error flowState={flowState} /> : undefined,
+      error:
+        status === "error" ? (
+          <div>
+            defue
+            <Error />
+          </div>
+        ) : undefined,
     };
 
     return slots;
-  }, [status, showBanner, flowState]);
+  }, [status, showBanner, flowState, children]);
 
+  console.log({children})
   const slots = useSlots({ children, defaultSlots });
 
   const handleSubmit = useCallback(

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -109,7 +109,6 @@ export const Form = ({
     return slots;
   }, [status, showBanner, flowState, children]);
 
-  console.log({children})
   const slots = useSlots({ children, defaultSlots });
 
   const handleSubmit = useCallback(

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -23,6 +23,7 @@ import { Flag } from "../input";
 export type Props = ConfigurationOverridesProps & {
   className?: string;
   onSuccess?: CreateFlowOptions["onSuccess"];
+  onError?: CreateFlowOptions["onError"];
   middleware?: LoginOptions["middleware"];
   children?: Slots<
     "initial" | "authenticating" | "success" | "error" | "footer"
@@ -43,6 +44,7 @@ export type InternalFormContextType = {
   selectedFactor?: Factor;
   setSelectedFactor: React.Dispatch<React.SetStateAction<Factor | undefined>>;
 };
+
 export const InternalFormContext = React.createContext<InternalFormContextType>(
   {
     flowState: null,
@@ -53,6 +55,7 @@ export const InternalFormContext = React.createContext<InternalFormContextType>(
     setSelectedFactor: () => null,
   }
 );
+
 export const useInternalFormContext = () => {
   return React.useContext(InternalFormContext);
 };
@@ -65,12 +68,13 @@ export const useInternalFormContext = () => {
 export const Form = ({
   className,
   onSuccess,
+  onError,
   factors,
   text,
   middleware,
   children,
 }: Props) => {
-  const flowState = useFlowState({ onSuccess });
+  const flowState = useFlowState({ onSuccess, onError });
   const { showBanner } = useConfiguration();
   const { lastHandle } = useLastHandle();
   const submitPayloadRef = React.useRef<PayloadOptions>({

--- a/packages/react/src/components/form/index.tsx
+++ b/packages/react/src/components/form/index.tsx
@@ -1,2 +1,5 @@
 export { Form } from "./form";
 export type { Props as FormProps } from "./form";
+
+// does not work as Form.Error
+export { Error as FormErrorState } from "./error";

--- a/packages/react/src/components/slot/index.tsx
+++ b/packages/react/src/components/slot/index.tsx
@@ -35,22 +35,16 @@ export function useSlots({ children, defaultSlots }: PopulateSlotsOptions) {
   const slots = React.useMemo(() => {
     const renderedSlots: Record<string, React.ReactNode> = { ...defaultSlots };
 
-    console.log("Here we are!", children);
-    
     React.Children.forEach(children, (child) => {
-      console.log("Here we are! 2");
       if (!React.isValidElement(child)) return;
-      
-      console.log("Here we are! 3");
+
       // TODO during development print a console log with details in the case of a missing slot
-      
       if (child.type !== Slot) {
         console.warn(`Passed a non-<Slot> component to a slot: ${child.type}`);
         return;
       }
-      
+
       if (child.props.name in defaultSlots) {
-        console.log("Here we are! 4", child.props.name);
         renderedSlots[child.props.name] = child;
       } else {
         console.warn(

--- a/packages/react/src/components/slot/index.tsx
+++ b/packages/react/src/components/slot/index.tsx
@@ -35,17 +35,22 @@ export function useSlots({ children, defaultSlots }: PopulateSlotsOptions) {
   const slots = React.useMemo(() => {
     const renderedSlots: Record<string, React.ReactNode> = { ...defaultSlots };
 
+    console.log("Here we are!", children);
+    
     React.Children.forEach(children, (child) => {
+      console.log("Here we are! 2");
       if (!React.isValidElement(child)) return;
-
+      
+      console.log("Here we are! 3");
       // TODO during development print a console log with details in the case of a missing slot
-
+      
       if (child.type !== Slot) {
         console.warn(`Passed a non-<Slot> component to a slot: ${child.type}`);
         return;
       }
-
+      
       if (child.props.name in defaultSlots) {
+        console.log("Here we are! 4", child.props.name);
         renderedSlots[child.props.name] = child;
       } else {
         console.warn(

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -47,6 +47,8 @@ export const TEXT = {
   "error.title": "Something went wrong...",
   "error.subtitle":
     "There has been an error while submitting your form. Please try again.",
+  "error.subtitle.rateLimit":
+    "Your request has been rate limited. Please try again later.",
   "factor.webauthn": "Passkeys",
   "factor.otpViaSms": "OTP via SMS",
   "factor.otpViaEmail": "OTP via email",

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -49,6 +49,7 @@ export const TEXT = {
     "There has been an error while submitting your form. Please try again.",
   "error.subtitle.rateLimit":
     "Your request has been rate limited. Please try again later.",
+  "error.retry": "Try again",
   "factor.webauthn": "Passkeys",
   "factor.otpViaSms": "OTP via SMS",
   "factor.otpViaEmail": "OTP via email",

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -197,6 +197,7 @@ const ComposedForm = () => {
   return (
     <ConfigurationProvider
       factors={[
+        { method: "webauthn" },
         { method: "email_link" },
         { method: "otp_via_email" },
         { method: "otp_via_sms" },
@@ -271,11 +272,11 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         <div>
           <div>
             <h2>Basic form</h2>
-            <BasicForm />
+            {/* <BasicForm /> */}
           </div>
           <div>
             <h2>Composed form</h2>
-            {/* <ComposedForm /> */}
+            <ComposedForm />
           </div>
         </div>
         <div>

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -18,6 +18,7 @@ import {
 } from "./main";
 import { defaultOrganization } from "./middleware/default-organization";
 import { Slot } from "./components/slot";
+import { FormErrorState } from "./components/form";
 
 const rootOid = "b6f94b67-d20f-7fc3-51df-bf6e3b82683e";
 
@@ -163,9 +164,9 @@ const BasicForm = () => {
   return (
     <ConfigurationProvider
       factors={[
+        { method: "webauthn" },
         { method: "email_link" },
         { method: "otp_via_email" },
-        { method: "webauthn" },
         { method: "otp_via_sms" },
         {
           method: "oidc",
@@ -228,6 +229,17 @@ const ComposedForm = () => {
                 <Form.Initial.OIDC />
                 <p>Some text below the form</p>
               </Slot>
+              <Slot name="error" key="error slot">
+                <FormErrorState key="error slot child">
+                  {({ context, retry, cancel }) => (
+                    <div>
+                      <h1>{context.error.message}</h1>
+                      <button onClick={retry}>Retry</button>
+                      <button onClick={cancel}>Cancel</button>
+                    </div>
+                  )}
+                </FormErrorState>
+              </Slot>
               <Slot name="footer">
                 <p>
                   Some footer text with a{" "}
@@ -263,17 +275,17 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
           </div>
           <div>
             <h2>Composed form</h2>
-            <ComposedForm />
+            {/* <ComposedForm /> */}
           </div>
         </div>
         <div>
           <div>
             <h2>Switch to default org</h2>
-            <Config />
+            {/* <Config /> */}
           </div>
           <div>
             <h2>Dynamic flow - factor based on handle</h2>
-            <ConfiguredDynamicFlow />
+            {/* <ConfiguredDynamicFlow /> */}
           </div>
         </div>
       </div>

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -165,6 +165,7 @@ const BasicForm = () => {
       factors={[
         { method: "email_link" },
         { method: "otp_via_email" },
+        { method: "webauthn" },
         { method: "otp_via_sms" },
         {
           method: "oidc",
@@ -246,10 +247,9 @@ const ComposedForm = () => {
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <SlashIDProvider
-      oid={import.meta.env.VITE_ORG_ID}
+      oid="00000000-0000-0000-1400-000000000000"
       themeProps={{ theme: "dark", className: "testClass" }}
-      tokenStorage="localStorage"
-      baseApiUrl="https://api.slashid.com"
+      baseApiUrl="https://slashid.local"
     >
       <div className="layout">
         <div>

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -180,7 +180,11 @@ const BasicForm = () => {
         <>
           <LoggedIn>Logged in!</LoggedIn>
           <LoggedOut>
-            <Form />
+            <Form
+              onError={(error, context) =>
+                console.log("onError", { error, context })
+              }
+            />
           </LoggedOut>
         </>
       </SlashIDLoaded>

--- a/packages/react/src/main.ts
+++ b/packages/react/src/main.ts
@@ -1,5 +1,5 @@
 import { DynamicFlow } from "./components/dynamic-flow";
-import { Form } from "./components/form";
+import { Form, FormErrorState } from "./components/form";
 import { Slot } from "./components/slot";
 import { GDPRConsentDialog } from "./components/gdpr-consent-dialog";
 import { Groups } from "./components/groups";
@@ -31,6 +31,7 @@ export {
   ConfigurationProvider,
   DynamicFlow,
   Form,
+  FormErrorState,
   GDPRConsentDialog,
   Groups,
   LoggedIn,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ importers:
       '@radix-ui/react-select': ^1.1.2
       '@radix-ui/react-switch': ^1.0.3
       '@radix-ui/react-tabs': ^1.0.1
-      '@slashid/slashid': ^3.14.1
+      '@slashid/slashid': link:/Users/ivankovic/projects/slashid/ng-evangelion/web/sdk
       '@storybook/addon-essentials': 7.0.0-rc.2
       '@storybook/addon-interactions': 7.4.0
       '@storybook/addon-links': 7.4.0
@@ -260,7 +260,7 @@ importers:
       country-list-with-dial-code-and-flag: 3.0.3
     devDependencies:
       '@faker-js/faker': 8.0.2
-      '@slashid/slashid': 3.14.1
+      '@slashid/slashid': link:../../../ng-evangelion/web/sdk
       '@storybook/addon-essentials': 7.0.0-rc.2_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-interactions': 7.4.0_zkisbtryv3xtasf42ecsrjh3ky
       '@storybook/addon-links': 7.4.0_biqbaboplfbrettd7655fr4n2y
@@ -5681,6 +5681,7 @@ packages:
       regenerator-runtime: 0.13.11
       url: 0.11.1
       uuid: 8.3.2
+    dev: false
 
   /@storybook/addon-actions/7.0.0-rc.2_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-e4VXOoeejRnz+yTtPGtenAvrMtwRWO4VRxbGBHDPyMo+FOlQPC6plOrQMZ+lSRaE20J3KfTo6wSLZgnHQUQtRw==}
@@ -7575,6 +7576,7 @@ packages:
 
   /@types/uuid/8.3.4:
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+    dev: false
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -8788,6 +8790,7 @@ packages:
     dependencies:
       udc: 1.0.1
       underscore: 1.13.6
+    dev: false
 
   /character-entities-html4/2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -9624,6 +9627,7 @@ packages:
 
   /dijkstrajs/1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+    dev: false
 
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -9633,6 +9637,7 @@ packages:
 
   /docdash/1.2.0:
     resolution: {integrity: sha512-IYZbgYthPTspgqYeciRJNPhSwL51yer7HAwDXhF5p+H7mTDbPvY3PCk/QDjNxdPCpWkaJVFC4t7iCNB/t9E5Kw==}
+    dev: false
 
   /doctrine/2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -9727,6 +9732,7 @@ packages:
 
   /encode-utf8/1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
+    dev: false
 
   /encodeurl/1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -12823,6 +12829,7 @@ packages:
 
   /jwt-decode/3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
+    dev: false
 
   /keyv/4.5.3:
     resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
@@ -13734,6 +13741,7 @@ packages:
 
   /mitt/3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+    dev: false
 
   /mixme/0.5.9:
     resolution: {integrity: sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==}
@@ -14481,6 +14489,7 @@ packages:
   /pngjs/5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+    dev: false
 
   /polished/4.2.2:
     resolution: {integrity: sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==}
@@ -14794,6 +14803,7 @@ packages:
 
   /punycode/1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+    dev: false
 
   /punycode/2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -14828,6 +14838,7 @@ packages:
       encode-utf8: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+    dev: false
 
   /qs/6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -14854,6 +14865,7 @@ packages:
   /querystring-es3/0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
+    dev: false
 
   /querystringify/2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -16741,6 +16753,7 @@ packages:
 
   /udc/1.0.1:
     resolution: {integrity: sha512-jv+D9de1flsum5QkFtBdjyppCQAdz9kTck/0xST5Vx48T9LL2BYnw0Iw77dSKDQ9KZ/PS3qPO1vfXHDpLZlxcQ==}
+    dev: false
 
   /ufo/1.2.0:
     resolution: {integrity: sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==}
@@ -16764,6 +16777,7 @@ packages:
 
   /underscore/1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
+    dev: false
 
   /unicode-canonical-property-names-ecmascript/2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -16967,6 +16981,7 @@ packages:
     dependencies:
       punycode: 1.4.1
       qs: 6.11.2
+    dev: false
 
   /use-callback-ref/1.3.0_fan5qbzahqtxlm5dzefqlqx5ia:
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
@@ -17085,6 +17100,7 @@ packages:
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+    dev: false
 
   /uvu/0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1350)

Render a special kind of error message when rate limit is hit.
Improved the `error` slot - now you can pass the `FormErrorState` component as a child to `Slot name="error"`. It receives a function as children which then gives you access to the underlying error and the actions to retry and cancel.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
