### PR TITLE
[SID-1361, SID-1360] Make sure the loading/error icons are displayed consistently, limit the logo height and use a safe default

### DIFF
--- a/.changeset/honest-vans-rescue.md
+++ b/.changeset/honest-vans-rescue.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Make sure the loading/error indicators are not hidden with div:empty as some apps use by default.

--- a/.changeset/ninety-boxes-rescue.md
+++ b/.changeset/ninety-boxes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Limit the form logo height to 32px per design. Default to the SlashID logo in case an invalid logo is configured.

--- a/packages/react/src/components/form/initial/initial.css.ts
+++ b/packages/react/src/components/form/initial/initial.css.ts
@@ -18,6 +18,7 @@ export const oidcList = style({
 export const logo = style({
   display: "flex",
   marginBottom: theme.space[4],
+  maxHeight: "32px",
 });
 
 export const header = style({

--- a/packages/react/src/components/form/initial/logo.tsx
+++ b/packages/react/src/components/form/initial/logo.tsx
@@ -2,13 +2,14 @@ import clsx from "clsx";
 import { Logo as TLogo } from "../../../context/config-context";
 import * as styles from "./initial.css";
 import { useConfiguration } from "../../../hooks/use-configuration";
+import { SlashID } from "../../icon/slashid";
 
 export type Props = {
   logo?: TLogo;
 };
 
 export const Logo: React.FC<Props> = ({ logo }) => {
-  if (typeof logo === "string") {
+  if (typeof logo === "string" && logo) {
     return (
       <img
         className={clsx("sid-logo", "sid-logo--image", styles.logo)}
@@ -18,9 +19,15 @@ export const Logo: React.FC<Props> = ({ logo }) => {
     );
   }
 
+  const logoComponent = logo ? logo : <SlashID />;
+
+  if (!logo) {
+    console.info("SlashID: No logo provided. Using default logo.");
+  }
+
   return (
     <div className={clsx("sid-logo", "sid-logo--component", styles.logo)}>
-      {logo}
+      {logoComponent}
     </div>
   );
 };

--- a/packages/react/src/components/spinner/circle.css.ts
+++ b/packages/react/src/components/spinner/circle.css.ts
@@ -76,6 +76,10 @@ const outerCircle = style({
   borderRadius: "100%",
   boxSizing: "border-box",
   opacity: 0.5,
+  // Shopify compatibility - it hides all empty divs by default
+  ":empty": {
+    display: "block",
+  },
 });
 export const outerCircleWithAnimation = style({
   width: "50px",
@@ -107,6 +111,10 @@ const middleCircle = style({
   height: "88px",
   borderRadius: "100%",
   boxSizing: "border-box",
+  // Shopify compatibility - it hides all empty divs by default
+  ":empty": {
+    display: "block",
+  },
 });
 export const middleCircleWithAnimation = style({
   width: "50px",
@@ -133,12 +141,17 @@ export const middleCircleVariants = styleVariants({
 });
 
 const innerCircle = style({
+  display: "block",
   position: "absolute",
   width: "53px",
   height: "53px",
   borderRadius: "100%",
   boxSizing: "border-box",
   boxShadow: "32px 80px 116px 0px rgba(91, 140, 255, 0.10)",
+  // Shopify compatibility - it hides all empty divs by default
+  ":empty": {
+    display: "block",
+  },
 });
 export const innerCircleWithAnimation = style({
   width: "50px",


### PR DESCRIPTION
## Description

[YouTrack issue 1](https://todo.irdcorp.dev/issue/SID-1360)
[YouTrack issue 2](https://todo.irdcorp.dev/issue/SID-1361)

Shopify uses a CSS reset that hides all empty divs and we use empty divs for loading and error icons. Added a rule to prevent that. 
Limited the height of the logo in the form to 32 pixels per design. Also the logo will now correctly use the SlashID logo if an empty string is provided in the configuration.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
