### PR TITLE
[SID-1424] Jump page: run the server via CLI

### DIFF
--- a/.changeset/old-pens-shake.md
+++ b/.changeset/old-pens-shake.md
@@ -1,0 +1,5 @@
+---
+"@slashid/jump-page": patch
+---
+
+Update dependencies

--- a/.changeset/silent-sloths-help.md
+++ b/.changeset/silent-sloths-help.md
@@ -1,0 +1,6 @@
+---
+"@slashid/react-primitives": minor
+"@slashid/react": patch
+---
+
+Add the skeleton component. Expose the jump page

--- a/apps/jump-page/README.md
+++ b/apps/jump-page/README.md
@@ -8,7 +8,20 @@ This package comes with CLI support so you can run it locally:
 
 ```bash
 npm install -g @slashid/jump-page
-sid-jump-cli
+```
+
+### CLI docs
+
+```bash
+Usage: sid-jump-cli serve [options]
+
+Start the development server
+
+Options:
+  -p, --port <number>   Port to use for the development server (default: 4321)
+  -a, --api-url <char>  SlashID API URL (default: "https://api.slashid.com")
+  -s, --sdk-url <char>  SlashID SDK URL (default: "https://cdn.slashid.com/sdk.html")
+  -h, --help            display help for command
 ```
 
 ## Astro gotchas

--- a/apps/jump-page/README.md
+++ b/apps/jump-page/README.md
@@ -2,6 +2,15 @@
 
 WIP jump page implementation for the SDK. SSG + client side rendering.
 
+## Running the app via CLI
+
+This package comes with CLI support so you can run it locally:
+
+```bash
+npm install -g @slashid/jump-page
+sid-jump-cli
+```
+
 ## Astro gotchas
 
 ### React hydration

--- a/apps/jump-page/cli.js
+++ b/apps/jump-page/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { exec } from "child_process";
+
+// Execute the "dev" script defined in package.json
+const childProcess = exec("npm run dev");
+
+childProcess.stdout.pipe(process.stdout);
+childProcess.stderr.pipe(process.stderr);
+
+childProcess.on("error", (error) => {
+  console.error(`Error: ${error.message}`);
+});
+
+childProcess.on("close", (code) => {
+  console.log(`Child process exited with code ${code}`);
+});

--- a/apps/jump-page/cli.js
+++ b/apps/jump-page/cli.js
@@ -1,17 +1,49 @@
 #!/usr/bin/env node
 
+import { program } from "commander";
 import { exec } from "child_process";
+import { createRequire } from "node:module";
 
-// Execute the "dev" script defined in package.json
-const childProcess = exec("npm run dev");
+const require = createRequire(import.meta.url);
 
-childProcess.stdout.pipe(process.stdout);
-childProcess.stderr.pipe(process.stderr);
+const packageJson = require("./package.json");
 
-childProcess.on("error", (error) => {
-  console.error(`Error: ${error.message}`);
-});
+program
+  .name("sid-jump-cli")
+  .description("/id CLI - Jump page")
+  .version(packageJson.version);
 
-childProcess.on("close", (code) => {
-  console.log(`Child process exited with code ${code}`);
-});
+program
+  .command("serve")
+  .description("Start the development server")
+  .option("-p, --port <number>", "Port to use for the development server", 4321)
+  .option(
+    "-a, --api-url <char>",
+    "SlashID API URL",
+    "https://api.sandbox.slashid.com"
+  )
+  .option(
+    "-s, --sdk-url <char>",
+    "SlashID SDK URL",
+    "https://cdn.sandbox.slashid.com/sdk.html"
+  )
+  .action((options) => {
+    const command = `PUBLIC_SID_SDK_URL=${options.sdkUrl} PUBLIC_SID_API_URL=${options.apiUrl} npm run dev`;
+
+    // Set the required env variables and execute the "dev" script defined in package.json
+    const childProcess = exec(command);
+
+    childProcess.stdout.pipe(process.stdout);
+    childProcess.stderr.pipe(process.stderr);
+
+    childProcess.on("error", (error) => {
+      console.error(`Error: ${error.message}`);
+    });
+
+    childProcess.on("close", (code) => {
+      console.log(`Child process exited with code ${code}`);
+    });
+  });
+
+// Parse the command line arguments
+program.parse();

--- a/apps/jump-page/package.json
+++ b/apps/jump-page/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "bin": {
-    "sid-cli": "./cli.js"
+    "sid-jump-cli": "./cli.js"
   },
   "scripts": {
     "dev": "astro dev",
@@ -22,6 +22,7 @@
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "astro": "^3.5.5",
+    "commander": "^11.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/apps/jump-page/package.json
+++ b/apps/jump-page/package.json
@@ -2,6 +2,10 @@
   "name": "@slashid/jump-page",
   "type": "module",
   "version": "0.0.1",
+  "private": false,
+  "publishConfig": {
+    "access": "restricted"
+  },
   "bin": {
     "sid-jump-cli": "./cli.js"
   },

--- a/apps/jump-page/package.json
+++ b/apps/jump-page/package.json
@@ -22,7 +22,7 @@
     "@astrojs/react": "^3.0.5",
     "@sentry/react": "^7.81.1",
     "@slashid/react-primitives": "workspace:*",
-    "@slashid/slashid": "link:/Users/ivankovic/projects/slashid/ng-evangelion/web/sdk",
+    "@slashid/slashid": "3.16.0",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "astro": "^3.5.5",

--- a/apps/jump-page/package.json
+++ b/apps/jump-page/package.json
@@ -2,6 +2,9 @@
   "name": "@slashid/jump-page",
   "type": "module",
   "version": "0.0.1",
+  "bin": {
+    "sid-cli": "./cli.js"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/apps/jump-page/src/components/app/app.component.tsx
+++ b/apps/jump-page/src/components/app/app.component.tsx
@@ -15,6 +15,7 @@ import { Flow, Error } from "../flow";
 import { Card } from "../card";
 
 import * as styles from "./app.css";
+import { config } from "../../config";
 
 export function App() {
   const isBrowser = !!globalThis.window;
@@ -29,6 +30,8 @@ export function App() {
 
       sidRef.current = new SlashID({
         analyticsEnabled: false,
+        sdkURL: config.sdkURL,
+        baseURL: config.baseURL,
       });
 
       setAppState("ready");

--- a/apps/jump-page/src/config.ts
+++ b/apps/jump-page/src/config.ts
@@ -1,0 +1,7 @@
+export const config = {
+  sdkURL:
+    import.meta.env.PUBLIC_SID_SDK_URL ||
+    "https://cdn.sandbox.slashid.com/sdk.html",
+  baseURL:
+    import.meta.env.PUBLIC_SID_API_URL || "https://api.sandbox.slashid.com",
+};

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "link:/Users/ivankovic/projects/slashid/ng-evangelion/web/sdk",
+    "@slashid/slashid": "3.16.0",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -98,7 +98,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.15.0",
+    "@slashid/slashid": ">= 3.16.0",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-primitives
       '@slashid/slashid':
-        specifier: link:/Users/ivankovic/projects/slashid/ng-evangelion/web/sdk
-        version: link:../../../ng-evangelion/web/sdk
+        specifier: 3.16.0
+        version: 3.16.0
       '@types/react':
         specifier: ^18.0.21
         version: 18.2.37
@@ -367,8 +367,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: link:/Users/ivankovic/projects/slashid/ng-evangelion/web/sdk
-        version: link:../../../ng-evangelion/web/sdk
+        specifier: 3.16.0
+        version: 3.16.0
       '@storybook/addon-essentials':
         specifier: 7.0.0-rc.2
         version: 7.0.0-rc.2(react-dom@18.2.0)(react@18.2.0)
@@ -6447,6 +6447,21 @@ packages:
 
   /@slashid/slashid@3.15.0:
     resolution: {integrity: sha512-2hlXmP2MrM76C7w5CBA2tKawszdr9Hz5c9nxhmFQAWz2MEUIe00/gfOydB3Pa5lBz54wzEEwl2AwXBSMhxKQNg==}
+    dependencies:
+      '@changesets/cli': 2.26.2
+      '@types/uuid': 8.3.4
+      changeset: 0.2.6
+      docdash: 1.2.0
+      jwt-decode: 3.1.2
+      mitt: 3.0.1
+      qrcode: 1.5.3
+      querystring-es3: 0.2.1
+      regenerator-runtime: 0.13.11
+      url: 0.11.3
+      uuid: 8.3.2
+
+  /@slashid/slashid@3.16.0:
+    resolution: {integrity: sha512-FfpC5COX5A+wE12i/k6wbIRg34+MmIM5elL+uwTIPfkYSQOJe2TF0wRg3G0zq5UBVFuWYQ+xbPJ4n1IM4PC21Q==}
     dependencies:
       '@changesets/cli': 2.26.2
       '@types/uuid': 8.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       astro:
         specifier: ^3.5.5
         version: 3.5.5(typescript@5.0.4)
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
       react:
         specifier: ^18.0.0
         version: 18.2.0
@@ -10059,6 +10062,11 @@ packages:
 
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  /commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+    dev: false
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1424)

`@slashid/jump-page` will now expose a CLI used to start the dev server, parametrized via CLI options.
This will be used in order to run the jump page locally, from `task up`.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
