### PR TITLE
[SID-1432] Catch react client-side errors

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.16.0",
+    "@slashid/slashid": "3.17.0",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -97,7 +97,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.16.0",
+    "@slashid/slashid": ">= 3.17.0",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/src/components/form/client-side-authentication-error-boundary.component.ts
+++ b/packages/react/src/components/form/client-side-authentication-error-boundary.component.ts
@@ -1,0 +1,25 @@
+import { SlashID, __INTERNAL_ONLY, errors } from "@slashid/slashid";
+import { Component, ReactNode } from "react";
+
+interface Props {
+  sid?: SlashID
+  children: ReactNode
+}
+
+export class ClientSideAuthenticationErrorBoundary extends Component<Props, any, any> {
+
+  public async componentDidCatch(error: Error) {
+    if (!this.props.sid) return
+    if (errors.isResponseError(error)) return
+    if (errors.isRateLimitError(error)) return
+
+    const internal = __INTERNAL_ONLY(this.props.sid)
+    internal.publish("clientSideError", undefined)
+  }
+
+  public render() {
+    return (
+      this.props.children
+    );
+  }
+}

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -20,6 +20,8 @@ import { Slots, useSlots } from "../slot";
 import { Factor } from "@slashid/slashid";
 import { PayloadOptions } from "./types";
 import { InternalFormContext } from "./internal-context";
+import { ClientSideAuthenticationErrorBoundary } from "./client-side-authentication-error-boundary.component";
+import { useSlashID } from "../../main";
 
 export type Props = ConfigurationOverridesProps & {
   className?: string;
@@ -36,7 +38,19 @@ export type Props = ConfigurationOverridesProps & {
  * The form can be customized significantly using the built-in slots and CSS custom properties.
  * Check the documentation for more information.
  */
-export const Form = ({
+export const Form = (props: Props) => {
+  const { sid } = useSlashID()
+
+  return (
+    <ClientSideAuthenticationErrorBoundary sid={sid}>
+      <FormComponent
+        {...props}
+      />
+    </ClientSideAuthenticationErrorBoundary>
+  )
+}
+
+const FormComponent = ({
   className,
   onSuccess,
   onError,
@@ -121,3 +135,4 @@ export const Form = ({
 
 Form.Initial = Initial;
 Form.Error = Error;
+FormComponent.displayName = "Form"


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1432)

Companion for: https://github.com/slashid/ng-evangelion/pull/1281

We assume any error within `<Form>` which is not a `ResponseError` adds friction to authentication, and report it as a `client_side_error` failure.
