### PR TITLE
[SID-maintenance] Bump up the core SDK to 3.17.1

### DIFF
--- a/.changeset/ninety-adults-allow.md
+++ b/.changeset/ninety-adults-allow.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Update the core SDK dependency to 3.17.1

--- a/packages/react-primitives/package.json
+++ b/packages/react-primitives/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.15.0",
+    "@slashid/slashid": "3.17.1",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -94,7 +94,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.15.0",
+    "@slashid/slashid": ">= 3.17.1",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.16.0",
+    "@slashid/slashid": "3.17.1",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -98,7 +98,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.16.0",
+    "@slashid/slashid": ">= 3.17.1",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -294,6 +294,7 @@ root.render(
       themeProps={{ theme: "dark" }}
       baseApiUrl="https://api.sandbox.slashid.com"
       tokenStorage="localStorage"
+      analyticsEnabled
     >
       <LogOut />
       <div className="layout">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,8 +367,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.16.0
-        version: 3.16.0
+        specifier: 3.17.1
+        version: 3.17.1
       '@storybook/addon-essentials':
         specifier: 7.0.0-rc.2
         version: 7.0.0-rc.2(react-dom@18.2.0)(react@18.2.0)
@@ -6474,6 +6474,23 @@ packages:
       regenerator-runtime: 0.13.11
       url: 0.11.3
       uuid: 8.3.2
+    dev: false
+
+  /@slashid/slashid@3.17.1:
+    resolution: {integrity: sha512-hlWvLRPK/XlE5V9QraYA+g4UkNqwVkMRIOtsxHYLC0TyMWRq9zpjGNGgavkPgDpLCjomg7KvMO5FVm5pu0LKMg==}
+    dependencies:
+      '@changesets/cli': 2.26.2
+      '@types/uuid': 8.3.4
+      changeset: 0.2.6
+      docdash: 1.2.0
+      jwt-decode: 3.1.2
+      mitt: 3.0.1
+      qrcode: 1.5.3
+      querystring-es3: 0.2.1
+      regenerator-runtime: 0.13.11
+      url: 0.11.3
+      uuid: 8.3.2
+    dev: true
 
   /@storybook/addon-actions@7.0.0-rc.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-e4VXOoeejRnz+yTtPGtenAvrMtwRWO4VRxbGBHDPyMo+FOlQPC6plOrQMZ+lSRaE20J3KfTo6wSLZgnHQUQtRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,8 +509,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.15.0
-        version: 3.15.0
+        specifier: 3.17.1
+        version: 3.17.1
       '@storybook/addon-essentials':
         specifier: 7.0.0-rc.2
         version: 7.0.0-rc.2(react-dom@18.2.0)(react@18.2.0)
@@ -6459,6 +6459,7 @@ packages:
       regenerator-runtime: 0.13.11
       url: 0.11.3
       uuid: 8.3.2
+    dev: false
 
   /@slashid/slashid@3.16.0:
     resolution: {integrity: sha512-FfpC5COX5A+wE12i/k6wbIRg34+MmIM5elL+uwTIPfkYSQOJe2TF0wRg3G0zq5UBVFuWYQ+xbPJ4n1IM4PC21Q==}


### PR DESCRIPTION
## Description

Bump up the core SDK to 3.17.1

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
