### PR TITLE
[SID-1460] React SDK: do not expose the internal package

### DIFF
--- a/.changeset/few-students-hide.md
+++ b/.changeset/few-students-hide.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react-primitives": patch
+---
+
+Make the react-primitives package private again

--- a/.changeset/hungry-experts-roll.md
+++ b/.changeset/hungry-experts-roll.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Fix the embedded types

--- a/.changeset/tidy-years-argue.md
+++ b/.changeset/tidy-years-argue.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Update the package so that it does not depend on react primitives on npm

--- a/packages/react-primitives/package.json
+++ b/packages/react-primitives/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@slashid/react-primitives",
   "version": "0.1.3",
-  "private": false,
+  "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "restricted"
   },
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,13 +22,16 @@
     "jwt"
   ],
   "type": "module",
-  "types": "dist/main.d.ts",
+  "types": "dist/react/src/main.d.ts",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./dist/main.js"
+      "import": {
+        "default": "./dist/main.js",
+        "types": "./dist/react/src/main.d.ts"
+      }
     },
     "./style.css": "./dist/style.css"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,8 +29,8 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/main.js",
-        "types": "./dist/react/src/main.d.ts"
+        "types": "./dist/react/src/main.d.ts",
+        "default": "./dist/main.js"
       }
     },
     "./style.css": "./dist/style.css"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,7 +52,6 @@
     "@radix-ui/react-select": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.1",
-    "@slashid/react-primitives": "workspace:*",
     "@vanilla-extract/css": "^1.9.2",
     "@vanilla-extract/dynamic": "^2.0.3",
     "@vanilla-extract/recipes": "^0.3.0",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -10,7 +10,10 @@
     "emitDeclarationOnly": true,
     "declarationDir": "./dist",
     "types": ["vitest/globals", "@types/testing-library__jest-dom"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@slashid/react-primitives": ["../react-primitives/src/main.ts"],
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/react/tsconfig.node.json
+++ b/packages/react/tsconfig.node.json
@@ -6,5 +6,10 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true
   },
-  "include": ["vite.config.ts", "package.json"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "vite.shared.ts",
+    "package.json"
+  ]
 }

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -7,6 +7,14 @@ import * as packageJson from "./package.json";
 
 export default defineConfig({
   plugins: [react(), vanillaExtractPlugin()],
+  resolve: {
+    alias: {
+      "@slashid/react-primitives": resolve(
+        __dirname,
+        "../react-primitives/src/main.ts"
+      ),
+    },
+  },
   build: {
     lib: {
       entry: resolve(__dirname, "src/main.ts"),

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,20 +1,11 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+import { config } from "./vite.shared";
 
 import * as packageJson from "./package.json";
 
 export default defineConfig({
-  plugins: [react(), vanillaExtractPlugin()],
-  resolve: {
-    alias: {
-      "@slashid/react-primitives": resolve(
-        __dirname,
-        "../react-primitives/src/main.ts"
-      ),
-    },
-  },
+  ...config,
   build: {
     lib: {
       entry: resolve(__dirname, "src/main.ts"),

--- a/packages/react/vite.shared.ts
+++ b/packages/react/vite.shared.ts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+
+// config entries to be shared between vite.config.ts and vitest.config.ts
+export const config = {
+  plugins: [react(), vanillaExtractPlugin()],
+  resolve: {
+    alias: {
+      "@slashid/react-primitives": resolve(
+        __dirname,
+        "../react-primitives/src/main.ts"
+      ),
+    },
+  },
+};

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
-import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+import { config } from "./vite.shared";
 
 export default defineConfig({
-  plugins: [react(), vanillaExtractPlugin()],
+  ...config,
   test: {
     globals: true,
     environment: "jsdom",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,9 +338,6 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.0.1
         version: 1.0.4(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
-      '@slashid/react-primitives':
-        specifier: workspace:*
-        version: link:../react-primitives
       '@vanilla-extract/css':
         specifier: ^1.9.2
         version: 1.14.0


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1460)

Previously to this PR, `@slashid/react-primitives` was an internal package that had to be exposed via `npm` in order for anyone to install the `@slashid/react` package, given that even though it was internal we still had a reference to it in `package.json`.

With these changes, we remove the dependency and include an alias in order for `@slashid/react` to import the code outside of its relative project root. This way, there is no dependency so customers now only need to install the base package and `@slashid/react-primitives` does not need to be published.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
