### PR TITLE
[SID-1464] Dont store bad handles with storeLastHandle

### DIFF
--- a/.changeset/loud-garlics-taste.md
+++ b/.changeset/loud-garlics-taste.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Invalid handles are no longer stored as part of storeLastHandle

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -8,7 +8,7 @@ const zlib = require("zlib");
 const filesToCheck = [
   "packages/react/dist/main.js",
   "packages/react/dist/style.css",
-  "packages/react/dist/main.d.ts",
+  "packages/react/dist/react/src/main.d.ts",
 ];
 
 function getFileSize(filePath) {

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -1,11 +1,26 @@
 import { Factor, SlashID, User } from "@slashid/slashid";
 import { ReactNode } from "react";
 
-export type HandleType = "email_address" | "phone_number";
+const handleTypes = [
+  "email_address",
+  "phone_number"
+] as const
+export type HandleType = typeof handleTypes[number]
 
 export interface Handle {
   type: HandleType;
   value: string;
+}
+
+export const isHandle = (obj: unknown): obj is Handle => {
+  if (!obj) return false
+  if (Array.isArray(obj)) return false
+  if (typeof obj !== "object") return false
+
+  const { type, value } = obj as Handle
+  if (!handleTypes.includes(type)) return false
+  
+  return typeof value === "string"
 }
 
 export interface LoginConfiguration {

--- a/packages/react/src/hooks/use-last-handle.ts
+++ b/packages/react/src/hooks/use-last-handle.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useCallback } from "react";
 import { isBrowser } from "@slashid/react-primitives";
-import { Handle } from "../domain/types";
+import { Handle, isHandle } from "../domain/types";
 import { useConfiguration } from "./use-configuration";
 import { useSlashID } from "./use-slash-id";
 
@@ -31,14 +31,18 @@ export const useLastHandle: UseLastHandle = () => {
     return JSON.parse(storedHandle);
   }, [storeLastHandle]);
 
-  const handler = useCallback((e: SuccessEvent) => {
+  const handler = useCallback(({ handle }: SuccessEvent) => {
     if (!isBrowser()) {
       return;
     }
 
+    if (!isHandle(handle)) {
+      return
+    }
+
     window.localStorage.setItem(
       STORAGE_LAST_HANDLE_KEY,
-      JSON.stringify(e.handle)
+      JSON.stringify(handle)
     );
   }, []);
 


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1464)

Fixes a bug with handle storage and direct-id, I'm adding `isHandle` type guard function which asserts the shape and content of things masquerading as a `Handle`.

#### Expected
Invalid handles should be discarded and not stored

#### Actual
If the `idFlowSucceeded` event fires and `handle` is `undefined`, `undefined` will be stored as the last handle. This causes things to break.


