### PR TITLE
React: graceful fail for block-all-cookies

### DIFF
--- a/.changeset/fifty-houses-chew.md
+++ b/.changeset/fifty-houses-chew.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Gracefully fail when users have localStorage blocked

--- a/packages/react/src/hooks/use-last-handle.ts
+++ b/packages/react/src/hooks/use-last-handle.ts
@@ -23,12 +23,16 @@ export const useLastHandle: UseLastHandle = () => {
       return undefined;
     }
 
-    const storedHandle = window.localStorage.getItem(STORAGE_LAST_HANDLE_KEY);
-    if (!storeLastHandle || !storedHandle) {
-      return undefined;
-    }
+    try {
+      const storedHandle = window.localStorage.getItem(STORAGE_LAST_HANDLE_KEY);
+      if (!storeLastHandle || !storedHandle) {
+        return undefined;
+      }
 
-    return JSON.parse(storedHandle);
+      return JSON.parse(storedHandle);
+    } catch {
+      return undefined
+    }
   }, [storeLastHandle]);
 
   const handler = useCallback(({ handle }: SuccessEvent) => {


### PR DESCRIPTION
Users with "Block all cookies" enabled will see a crash when loading the form.

## Change
- Fail gracefully if accessing local storage fails when checking last handle