### PR TITLE
[SID-1546] Add possibility to specify allowed handle types for factors with multiple handle types

### DIFF
--- a/.changeset/khaki-forks-do.md
+++ b/.changeset/khaki-forks-do.md
@@ -1,0 +1,6 @@
+---
+"@slashid/react": minor
+"@slashid/react-primitives": patch
+---
+
+Add `allowedHandleTypes` configuration option to password

--- a/.changeset/khaki-forks-do.md
+++ b/.changeset/khaki-forks-do.md
@@ -1,6 +1,5 @@
 ---
 "@slashid/react": minor
-"@slashid/react-primitives": patch
 ---
 
 Add `allowedHandleTypes` configuration option to password

--- a/packages/react-primitives/src/components/tabs/index.tsx
+++ b/packages/react-primitives/src/components/tabs/index.tsx
@@ -12,16 +12,22 @@ type Props = {
   tabs: Tab[];
   className?: string;
   defaultValue?: string;
+  testId?: string;
 };
 
-export const Tabs: React.FC<Props> = ({ className, tabs, defaultValue }) => {
+export const Tabs: React.FC<Props> = ({
+  className,
+  tabs,
+  defaultValue,
+  testId,
+}) => {
   if (!tabs.length) {
     return null;
   }
 
   return (
     <RadixTabs.Root
-      data-testid="sid-handle-type-tabs"
+      data-testid={testId}
       className={clsx("sid-tabs", className)}
       defaultValue={defaultValue ?? tabs[0]?.id}
     >

--- a/packages/react-primitives/src/components/tabs/index.tsx
+++ b/packages/react-primitives/src/components/tabs/index.tsx
@@ -21,6 +21,7 @@ export const Tabs: React.FC<Props> = ({ className, tabs, defaultValue }) => {
 
   return (
     <RadixTabs.Root
+      data-testid="sid-handle-type-tabs"
       className={clsx("sid-tabs", className)}
       defaultValue={defaultValue ?? tabs[0]?.id}
     >

--- a/packages/react/src/components/configuration-overrides/index.tsx
+++ b/packages/react/src/components/configuration-overrides/index.tsx
@@ -1,11 +1,11 @@
-import { Factor } from "@slashid/slashid";
 import { PropsWithChildren } from "react";
 import { useConfiguration } from "../../hooks/use-configuration";
 import { ConfigurationProvider } from "../../context/config-context";
 import { TextConfig } from "../text/constants";
+import { FactorConfiguration } from "../../domain/types";
 
 export type ConfigurationOverridesProps = {
-  factors?: Factor[];
+  factors?: FactorConfiguration[];
   text?: Partial<TextConfig>;
 };
 

--- a/packages/react/src/components/dynamic-flow/configured-handle-form.tsx
+++ b/packages/react/src/components/dynamic-flow/configured-handle-form.tsx
@@ -66,6 +66,7 @@ export const ConfiguredHandleForm = ({ handleSubmit, lastHandle }: Props) => {
   return (
     <>
       <Tabs
+        testId="sid-handle-type-tabs"
         className={sprinkles({ marginY: "6" })}
         defaultValue={tabIDByHandle[lastHandle?.type ?? "email_address"]}
         tabs={[

--- a/packages/react/src/components/dynamic-flow/handle-form.tsx
+++ b/packages/react/src/components/dynamic-flow/handle-form.tsx
@@ -110,7 +110,10 @@ export const HandleForm: React.FC<Props> = ({
         id={`sid-input-${handleType}`}
         name={handleType}
         label={text["initial.handle.email"]}
-        placeholder={text["initial.handle.email.placeholder"]}
+        placeholder={
+          text["initial.handle.phone.email"] ||
+          text["initial.handle.email.placeholder"]
+        }
         value={values[handleType] ?? ""}
         onChange={registerField(handleType, {
           defaultValue,

--- a/packages/react/src/components/dynamic-flow/handle-form.tsx
+++ b/packages/react/src/components/dynamic-flow/handle-form.tsx
@@ -20,7 +20,10 @@ import { useConfiguration } from "../../hooks/use-configuration";
 import { useForm } from "../../hooks/use-form";
 
 import { ErrorMessage } from "../form/error-message";
-import { isValidEmail, isValidPhoneNumber } from "../form/authenticating/validation";
+import {
+  isValidEmail,
+  isValidPhoneNumber,
+} from "../form/authenticating/validation";
 import { TextConfigKey } from "../text/constants";
 
 import * as styles from "./dynamic-flow.css";
@@ -107,7 +110,7 @@ export const HandleForm: React.FC<Props> = ({
         id={`sid-input-${handleType}`}
         name={handleType}
         label={text["initial.handle.email"]}
-        placeholder={text["initial.handle.phone.email"]}
+        placeholder={text["initial.handle.email.placeholder"]}
         value={values[handleType] ?? ""}
         onChange={registerField(handleType, {
           defaultValue,

--- a/packages/react/src/components/form/form-customisation.test.tsx
+++ b/packages/react/src/components/form/form-customisation.test.tsx
@@ -168,6 +168,21 @@ describe("#Form - customisation", () => {
 
       expect(screen.queryByTestId("sid-handle-type-tabs")).toBeInTheDocument();
     });
+
+    test("should render tabs when phone number factor is present", () => {
+      render(
+        <TestSlashIDProvider sdkState="ready">
+          <Form
+            factors={[
+              { method: "password", allowedHandleTypes: ["email_address"] },
+              { method: "otp_via_sms" },
+            ]}
+          />
+        </TestSlashIDProvider>
+      );
+
+      expect(screen.queryByTestId("sid-handle-type-tabs")).toBeInTheDocument();
+    });
   });
 
   describe("#Form.Initial - composition API", () => {

--- a/packages/react/src/components/form/form-customisation.test.tsx
+++ b/packages/react/src/components/form/form-customisation.test.tsx
@@ -8,6 +8,7 @@ import { ConfigurationProvider } from "../../main";
 import { useState } from "react";
 import { Factor } from "@slashid/slashid";
 import { Handle } from "../../domain/types";
+import { TEXT } from "../text/constants";
 
 describe("#Form - customisation", () => {
   test(`should not render any components that are not a <Slot name="initial | authenticating | success | error | footer">`, () => {
@@ -117,6 +118,56 @@ describe("#Form - customisation", () => {
     await expect(
       screen.findByTestId("custom-error-function")
     ).resolves.toBeInTheDocument();
+  });
+
+  describe("#Form - `allowedFactorMethods`", () => {
+    test(`should render only phone input when option set to ["phone_number"]`, () => {
+      render(
+        <TestSlashIDProvider sdkState="ready">
+          <Form
+            factors={[
+              { method: "password", allowedHandleTypes: ["phone_number"] },
+            ]}
+          />
+        </TestSlashIDProvider>
+      );
+
+      expect(
+        screen.queryByPlaceholderText(TEXT["initial.handle.phone.placeholder"])
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText(TEXT["initial.handle.email.placeholder"])
+      ).not.toBeInTheDocument();
+    });
+
+    test(`should render only email input when option set to ["email_address"]`, () => {
+      render(
+        <TestSlashIDProvider sdkState="ready">
+          <Form
+            factors={[
+              { method: "password", allowedHandleTypes: ["email_address"] },
+            ]}
+          />
+        </TestSlashIDProvider>
+      );
+
+      expect(
+        screen.queryByPlaceholderText(TEXT["initial.handle.email.placeholder"])
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText(TEXT["initial.handle.phone.placeholder"])
+      ).not.toBeInTheDocument();
+    });
+
+    test("should render tabs with handle type selection when option is unset", () => {
+      render(
+        <TestSlashIDProvider sdkState="ready">
+          <Form factors={[{ method: "password" }]} />
+        </TestSlashIDProvider>
+      );
+
+      expect(screen.queryByTestId("sid-handle-type-tabs")).toBeInTheDocument();
+    });
   });
 
   describe("#Form.Initial - composition API", () => {

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -371,7 +371,7 @@ describe("<Form /> configuration", () => {
 
     expect(getItemSpy).toHaveBeenCalledWith(STORAGE_LAST_HANDLE_KEY);
     expect(
-      screen.getByPlaceholderText(TEXT["initial.handle.phone.email"])
+      screen.getByPlaceholderText(TEXT["initial.handle.email.placeholder"])
     ).toHaveValue(testEmail);
   });
 

--- a/packages/react/src/components/form/initial/controls.tsx
+++ b/packages/react/src/components/form/initial/controls.tsx
@@ -365,7 +365,7 @@ const HandleInput: React.FC<PropsInternal> = ({
         id={`sid-input-${handleType}`}
         name={handleType}
         label={text["initial.handle.email"]}
-        placeholder={text["initial.handle.phone.email"]}
+        placeholder={text["initial.handle.email.placeholder"]}
         value={values[handleType] ?? ""}
         onChange={registerField(handleType, {
           defaultValue,

--- a/packages/react/src/components/form/initial/controls.tsx
+++ b/packages/react/src/components/form/initial/controls.tsx
@@ -366,7 +366,10 @@ const HandleInput: React.FC<PropsInternal> = ({
         id={`sid-input-${handleType}`}
         name={handleType}
         label={text["initial.handle.email"]}
-        placeholder={text["initial.handle.email.placeholder"]}
+        placeholder={
+          text["initial.handle.phone.email"] ||
+          text["initial.handle.email.placeholder"]
+        }
         value={values[handleType] ?? ""}
         onChange={registerField(handleType, {
           defaultValue,

--- a/packages/react/src/components/form/initial/controls.tsx
+++ b/packages/react/src/components/form/initial/controls.tsx
@@ -203,6 +203,7 @@ const FormInput = ({ children }: FormInputProps) => {
   } else {
     return (
       <Tabs
+        testId="sid-handle-type-tabs"
         className={sprinkles({ marginY: "6" })}
         defaultValue={tabIDByHandle[lastHandle?.type ?? "email_address"]}
         tabs={[

--- a/packages/react/src/components/test-utils.ts
+++ b/packages/react/src/components/test-utils.ts
@@ -12,7 +12,7 @@ import {
 
 export const inputEmail = (
   value: string,
-  inputPlaceholder: string = TEXT["initial.handle.phone.email"]
+  inputPlaceholder: string = TEXT["initial.handle.email.placeholder"]
 ) => {
   const input = screen.getByPlaceholderText(inputPlaceholder);
   fireEvent.change(input, { target: { value } });

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -11,7 +11,7 @@ export const TEXT = {
   "initial.authenticationMethod": "Authentication method",
   "initial.handle.email": "Email address",
   "initial.handle.phone": "Phone number",
-  "initial.handle.phone.email": "Type your email",
+  "initial.handle.email.placeholder": "Type your email",
   "initial.handle.phone.placeholder": "Type your phone number",
   "initial.submit": "Continue",
   "initial.divider": "or",

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -196,4 +196,9 @@ export const TEXT = {
     "Cookies that track your online behaviour, such as clicks, preferences, device specifications, location, and search history. This data helps in targeted advertising and gathering website analytics.",
   "gdpr.dialog.error.title": "Oops!",
   "gdpr.dialog.error.subtitle": "Looks like something went wrong...",
+  // deprecated keys
+  /**
+   * @deprecated Use 'initial.handle.email.placeholder' instead
+   */
+  "initial.handle.phone.email": "",
 };

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -29,7 +29,7 @@ const initialFactors: Factor[] = [
     method: "oidc",
     options: {
       provider: "google",
-      client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID,
+      client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID ?? "test_oidc",
     },
   },
 ];
@@ -42,7 +42,7 @@ const withWan: FactorConfiguration[] = [
     method: "oidc",
     options: {
       provider: "google",
-      client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID,
+      client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID ?? "test_oidc_1",
     },
   },
   {
@@ -50,7 +50,7 @@ const withWan: FactorConfiguration[] = [
     label: "Google SSO - label test",
     options: {
       provider: "google",
-      client_id: "TEST",
+      client_id: "test_oidc_2",
     },
   },
 ];
@@ -142,7 +142,7 @@ const getFactor = (handle?: Handle) => {
       method: "oidc",
       options: {
         provider: "google",
-        client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID,
+        client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID ?? "test_oidc",
       },
     };
     return oidcFactor;
@@ -173,13 +173,13 @@ const BasicForm = () => {
           method: "oidc",
           options: {
             provider: "okta",
-            client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID,
+            client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID ?? "test_oidc",
           },
         },
         {
           method: "saml",
           options: {
-            provider_credentials_id: "test",
+            provider_credentials_id: "test_saml",
           },
           label: "SAML test",
           logo: "https://www.oasis-open.org/committees/download.php/29723/draft-saml-logo-03.png",
@@ -214,14 +214,14 @@ const ComposedForm = () => {
           method: "oidc",
           options: {
             provider: "google",
-            client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID,
+            client_id: import.meta.env.VITE_GOOGLE_SSO_CLIENT_ID ?? "test_oidc",
           },
         },
 
         {
           method: "saml",
           options: {
-            provider_credentials_id: "test",
+            provider_credentials_id: "test_saml",
           },
         },
       ]}

--- a/packages/react/src/domain/handles.ts
+++ b/packages/react/src/domain/handles.ts
@@ -28,28 +28,34 @@ const FACTORS_WITH_EMAIL = [
 const FACTORS_WITH_PHONE = ["otp_via_sms", "sms_link", "password"];
 const SSO_FACTORS = ["oidc", "saml"];
 
+function isHandleTypeAllowed(
+  factor: Factor | FactorWithAllowedHandleTypes,
+  handleType: HandleType
+): boolean {
+  if (!isFactorWithAllowedHandleTypes(factor)) {
+    return true;
+  }
+
+  return factor.allowedHandleTypes!.includes(handleType);
+}
+
 function getPossibleHandleTypes(
   factor: Factor | FactorWithAllowedHandleTypes
 ): Set<HandleType> {
   const handleTypes = new Set<HandleType>();
 
-  if (FACTORS_WITH_EMAIL.includes(factor.method)) {
-    if (
-      !isFactorWithAllowedHandleTypes(factor) ||
-      (isFactorWithAllowedHandleTypes(factor) &&
-        factor.allowedHandleTypes?.includes("email_address"))
-    )
-      handleTypes.add("email_address");
+  if (
+    FACTORS_WITH_EMAIL.includes(factor.method) &&
+    isHandleTypeAllowed(factor, "email_address")
+  ) {
+    handleTypes.add("email_address");
   }
 
-  if (FACTORS_WITH_PHONE.includes(factor.method)) {
-    if (
-      !isFactorWithAllowedHandleTypes(factor) ||
-      (isFactorWithAllowedHandleTypes(factor) &&
-        factor.allowedHandleTypes?.includes("phone_number"))
-    ) {
-      handleTypes.add("phone_number");
-    }
+  if (
+    FACTORS_WITH_PHONE.includes(factor.method) &&
+    isHandleTypeAllowed(factor, "phone_number")
+  ) {
+    handleTypes.add("phone_number");
   }
 
   return handleTypes;

--- a/packages/react/src/domain/handles.ts
+++ b/packages/react/src/domain/handles.ts
@@ -13,6 +13,7 @@ import {
   FactorPassword,
   FactorSSO,
   FactorSmsLink,
+  FactorWithAllowedHandleTypes,
   Handle,
   HandleType,
   isFactorWithAllowedHandleTypes,
@@ -27,19 +28,28 @@ const FACTORS_WITH_EMAIL = [
 const FACTORS_WITH_PHONE = ["otp_via_sms", "sms_link", "password"];
 const SSO_FACTORS = ["oidc", "saml"];
 
-function getPossibleHandleTypes(factor: Factor): Set<HandleType> {
+function getPossibleHandleTypes(
+  factor: Factor | FactorWithAllowedHandleTypes
+): Set<HandleType> {
   const handleTypes = new Set<HandleType>();
 
-  if (isFactorWithAllowedHandleTypes(factor)) {
-    return new Set(factor.allowedHandleTypes);
-  }
-
   if (FACTORS_WITH_EMAIL.includes(factor.method)) {
-    handleTypes.add("email_address");
+    if (
+      !isFactorWithAllowedHandleTypes(factor) ||
+      (isFactorWithAllowedHandleTypes(factor) &&
+        factor.allowedHandleTypes?.includes("email_address"))
+    )
+      handleTypes.add("email_address");
   }
 
   if (FACTORS_WITH_PHONE.includes(factor.method)) {
-    handleTypes.add("phone_number");
+    if (
+      !isFactorWithAllowedHandleTypes(factor) ||
+      (isFactorWithAllowedHandleTypes(factor) &&
+        factor.allowedHandleTypes?.includes("phone_number"))
+    ) {
+      handleTypes.add("phone_number");
+    }
   }
 
   return handleTypes;

--- a/packages/react/src/domain/handles.ts
+++ b/packages/react/src/domain/handles.ts
@@ -15,6 +15,7 @@ import {
   FactorSmsLink,
   Handle,
   HandleType,
+  isFactorWithAllowedHandleTypes,
 } from "./types";
 
 const FACTORS_WITH_EMAIL = [
@@ -28,6 +29,10 @@ const SSO_FACTORS = ["oidc", "saml"];
 
 function getPossibleHandleTypes(factor: Factor): Set<HandleType> {
   const handleTypes = new Set<HandleType>();
+
+  if (isFactorWithAllowedHandleTypes(factor)) {
+    return new Set(factor.allowedHandleTypes);
+  }
 
   if (FACTORS_WITH_EMAIL.includes(factor.method)) {
     handleTypes.add("email_address");

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -68,7 +68,7 @@ export type FactorSmsLink = Extract<Factor, { method: "sms_link" }>;
 export type FactorWithAllowedHandleTypes = Factor & {
   /**
    * Limits the allowed handle types for given factor method to the ones specified in the array.
-   * When this option is not specified, all factors are allowed.
+   * When this option is not specified, all supported handle types are allowed.
    */
   allowedHandleTypes?: NonEmptyArray<HandleType>;
 };
@@ -129,7 +129,19 @@ export type MaybeArray<T> = T | T[];
 export function isFactorWithAllowedHandleTypes(
   factor: Factor
 ): factor is FactorWithAllowedHandleTypes {
-  return Object.hasOwn(factor, "allowedHandleTypes");
+  // check if factor has `allowedHandleTypes` property
+  if (!Object.hasOwn(factor, "allowedHandleTypes")) {
+    return false;
+  }
+
+  // check if the values in `allowedHandleTypes` array are correct
+  return (factor as FactorWithAllowedHandleTypes).allowedHandleTypes!.every(
+    (handleType) => {
+      return handleTypes.includes(handleType);
+    }
+  );
+
+  return true;
 }
 
 export type NonEmptyArray<T> = [T, ...T[]];

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -66,7 +66,11 @@ export type FactorSmsLink = Extract<Factor, { method: "sms_link" }>;
  * Utility type to specify allowed handle types in case given factor supports more than one.
  */
 export type FactorWithAllowedHandleTypes = Factor & {
-  allowedHandleTypes?: HandleType[];
+  /**
+   * Limits the allowed handle types for given factor method to the ones specified in the array.
+   * When this option is not specified, all factors are allowed.
+   */
+  allowedHandleTypes?: NonEmptyArray<HandleType>;
 };
 
 /**
@@ -127,3 +131,5 @@ export function isFactorWithAllowedHandleTypes(
 ): factor is FactorWithAllowedHandleTypes {
   return Object.hasOwn(factor, "allowedHandleTypes");
 }
+
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -63,6 +63,13 @@ export type FactorEmailLink = Extract<Factor, { method: "email_link" }>;
 export type FactorSmsLink = Extract<Factor, { method: "sms_link" }>;
 
 /**
+ * Utility type to specify allowed handle types in case given factor supports more than one.
+ */
+export type FactorWithAllowedHandleTypes = Factor & {
+  allowedHandleTypes?: HandleType[];
+};
+
+/**
  * This makes it possible to add a label to the configured OIDC factors.
  * This is useful when you want to change the default display (capitalized provider name).
  */
@@ -77,13 +84,17 @@ export type FactorCustomizableSAML = FactorSAML & {
   logo?: string | ReactNode;
 };
 
+export type FactorCustomizablePassword = FactorPassword &
+  FactorWithAllowedHandleTypes;
+
 /**
  * All factors that can be configured for usage in our UI components.
  */
 export type FactorConfiguration =
-  | Exclude<Factor, FactorOIDC | FactorSAML>
+  | Exclude<Factor, FactorOIDC | FactorSAML | FactorPassword>
   | FactorLabeledOIDC
-  | FactorCustomizableSAML;
+  | FactorCustomizableSAML
+  | FactorCustomizablePassword;
 
 export type LogIn = (
   config: LoginConfiguration,
@@ -110,3 +121,9 @@ export type ValidationError = {
 export type Validator<T = unknown> = (value: T) => ValidationError | undefined;
 
 export type MaybeArray<T> = T | T[];
+
+export function isFactorWithAllowedHandleTypes(
+  factor: Factor
+): factor is FactorWithAllowedHandleTypes {
+  return Object.hasOwn(factor, "allowedHandleTypes");
+}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1546)

This change adds `allowedHandleTypes` to `password` factor method, as it's currently the only factor that supports both email and phone number handle types.

The motivation behind this change is: there are valid use cases where the user wants to explicitly declare the supported handle types. Good example is Shopify and SlashID Login app - Multipass works only with emails, so the phone number option should not be shown.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
