### PR TITLE
[SID-1421][SID-1529] Improve OTP error & resend handling

### DIFF
--- a/.changeset/tidy-icons-vanish.md
+++ b/.changeset/tidy-icons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react-primitives": minor
+---
+
+Create <Delayed> component

--- a/.changeset/wise-actors-taste.md
+++ b/.changeset/wise-actors-taste.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Improve handling of OTP error & resend

--- a/packages/react-primitives/src/components/delayed/index.tsx
+++ b/packages/react-primitives/src/components/delayed/index.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect, type ReactNode } from "react";
+
+type Props = {
+  delayMs: number;
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+export function Delayed({ delayMs, children, fallback }: Props) {
+  const [render, setRender] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setRender(true);
+    }, delayMs);
+
+    return () => clearTimeout(timeout);
+  }, [delayMs]);
+
+  return <>{render ? children : fallback ?? null}</>;
+}

--- a/packages/react-primitives/src/components/delayed/index.tsx
+++ b/packages/react-primitives/src/components/delayed/index.tsx
@@ -1,12 +1,19 @@
 import { useState, useEffect, type ReactNode } from "react";
 
 type Props = {
+  /** Period of time, after which the component will render its children */
   delayMs: number;
   children: ReactNode;
+  /** Optional fallback component rendered initially, replaced by children after the delay */
   fallback?: ReactNode;
+  /** Optional CSS class name for the wrapper */
+  className?: string;
 };
 
-export function Delayed({ delayMs, children, fallback }: Props) {
+/**
+ * Utility component used to render its children after specified period of time
+ */
+export function Delayed({ delayMs, children, fallback, className }: Props) {
   const [render, setRender] = useState(false);
 
   useEffect(() => {
@@ -17,5 +24,7 @@ export function Delayed({ delayMs, children, fallback }: Props) {
     return () => clearTimeout(timeout);
   }, [delayMs]);
 
-  return <>{render ? children : fallback ?? null}</>;
+  return (
+    <div className={className}>{render ? children : fallback ?? null}</div>
+  );
 }

--- a/packages/react-primitives/src/components/input/input.otp.css.ts
+++ b/packages/react-primitives/src/components/input/input.otp.css.ts
@@ -22,6 +22,7 @@ export const otpInput = style({
   fontFamily: publicVariables.font.fontFamily,
   color: publicVariables.color.foreground,
   textAlign: "center",
+  marginBottom: "8px",
 
   "::placeholder": {
     color: publicVariables.color.placeholder,

--- a/packages/react-primitives/src/components/input/input.otp.css.ts
+++ b/packages/react-primitives/src/components/input/input.otp.css.ts
@@ -22,7 +22,6 @@ export const otpInput = style({
   fontFamily: publicVariables.font.fontFamily,
   color: publicVariables.color.foreground,
   textAlign: "center",
-  marginBottom: "8px",
 
   "::placeholder": {
     color: publicVariables.color.placeholder,

--- a/packages/react-primitives/src/main.ts
+++ b/packages/react-primitives/src/main.ts
@@ -30,6 +30,7 @@ import { TextContext, TextProvider } from "./components/text/text-context";
 import { isBrowser } from "./browser/is-browser";
 import { MemoryStorage } from "./browser/memory-storage";
 import { CookieStorage } from "./browser/cookie-storage";
+import { Delayed } from "./components/delayed";
 
 // theming
 export * from "./theme/theme.css";
@@ -58,6 +59,7 @@ export {
   Tabs,
   Teleport,
   Text,
+  Delayed,
 };
 
 // context

--- a/packages/react/src/components/form/authenticating/authenticating.css.ts
+++ b/packages/react/src/components/form/authenticating/authenticating.css.ts
@@ -23,3 +23,9 @@ export const passwordRecoveryPrompt = style({
   alignItems: "baseline",
   marginTop: "8px",
 });
+
+export const formInner = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+});

--- a/packages/react/src/components/form/authenticating/authenticating.css.ts
+++ b/packages/react/src/components/form/authenticating/authenticating.css.ts
@@ -1,4 +1,4 @@
-import { style } from "@vanilla-extract/css";
+import { keyframes, style } from "@vanilla-extract/css";
 
 export const retryPrompt = style({
   display: "flex",
@@ -28,4 +28,13 @@ export const formInner = style({
   display: "flex",
   flexDirection: "column",
   gap: "8px",
+});
+
+const fadeIn = keyframes({
+  "0%": { opacity: "0" },
+  "100%": { opacity: "1" },
+});
+
+export const wrapper = style({
+  animation: `${fadeIn} 0.3s`,
 });

--- a/packages/react/src/components/form/authenticating/messages.ts
+++ b/packages/react/src/components/form/authenticating/messages.ts
@@ -1,14 +1,19 @@
 import { Factor } from "@slashid/slashid";
 import { TextConfigKey } from "../../text/constants";
 
+type AuthenticatingMessageOptions = {
+  isSubmitting: boolean;
+  hasRetried: boolean;
+};
+
 // TODO add case for password
 export function getAuthenticatingMessage(
   factor: Factor,
-  formState: "initial" | "input" | "submitting" | "retry" = "initial"
+  { isSubmitting, hasRetried }: AuthenticatingMessageOptions = {
+    isSubmitting: false,
+    hasRetried: false,
+  }
 ): { title: TextConfigKey; message: TextConfigKey } {
-  const isSubmitting = formState === "submitting";
-  const isRetry = formState === "retry";
-
   switch (factor.method) {
     case "oidc":
       return {
@@ -39,16 +44,16 @@ export function getAuthenticatingMessage(
       };
     }
     case "otp_via_email":
+      if (isSubmitting && hasRetried) {
+        return {
+          message: "authenticating.retry.message.emailOtp",
+          title: "authenticating.retry.title.emailOtp",
+        };
+      }
       if (isSubmitting) {
         return {
           message: "authenticating.submitting.message.emailOtp",
           title: "authenticating.submitting.title.emailOtp",
-        };
-      }
-      if (isRetry) {
-        return {
-          message: "authenticating.retry.message.emailOtp",
-          title: "authenticating.retry.title.emailOtp",
         };
       }
       return {

--- a/packages/react/src/components/form/authenticating/messages.ts
+++ b/packages/react/src/components/form/authenticating/messages.ts
@@ -4,8 +4,11 @@ import { TextConfigKey } from "../../text/constants";
 // TODO add case for password
 export function getAuthenticatingMessage(
   factor: Factor,
-  isSubmitting = false
+  formState: "initial" | "input" | "submitting" | "retry" = "initial"
 ): { title: TextConfigKey; message: TextConfigKey } {
+  const isSubmitting = formState === "submitting";
+  const isRetry = formState === "retry";
+
   switch (factor.method) {
     case "oidc":
       return {
@@ -40,6 +43,12 @@ export function getAuthenticatingMessage(
         return {
           message: "authenticating.submitting.message.emailOtp",
           title: "authenticating.submitting.title.emailOtp",
+        };
+      }
+      if (isRetry) {
+        return {
+          message: "authenticating.retry.message.emailOtp",
+          title: "authenticating.retry.title.emailOtp",
         };
       }
       return {

--- a/packages/react/src/components/form/authenticating/messages.ts
+++ b/packages/react/src/components/form/authenticating/messages.ts
@@ -32,6 +32,12 @@ export function getAuthenticatingMessage(
         title: "authenticating.title.smsLink",
       };
     case "otp_via_sms": {
+      if (isSubmitting && hasRetried) {
+        return {
+          message: "authenticating.retry.message.smsOtp",
+          title: "authenticating.retry.title.smsOtp",
+        };
+      }
       if (isSubmitting) {
         return {
           message: "authenticating.submitting.message.smsOtp",

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -133,15 +133,17 @@ export const OTPState = ({ flowState }: Props) => {
           onSubmit={registerSubmit(handleSubmit)}
           className={styles.otpForm}
         >
-          <OtpInput
-            shouldAutoFocus
-            inputType="number"
-            value={values["otp"] ?? ""}
-            onChange={handleChange}
-            numInputs={OTP_CODE_LENGTH}
-          />
-          <input hidden type="submit" ref={submitInputRef} />
-          <ErrorMessage name="otp" />
+          <div className={styles.formInner}>
+            <OtpInput
+              shouldAutoFocus
+              inputType="number"
+              value={values["otp"] ?? ""}
+              onChange={handleChange}
+              numInputs={OTP_CODE_LENGTH}
+            />
+            <input hidden type="submit" ref={submitInputRef} />
+            <ErrorMessage name="otp" />
+          </div>
         </form>
       )}
       {formState === "submitting" && <Loader />}

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -51,15 +51,12 @@ export const OTPState = ({ flowState }: Props) => {
     clearError,
   } = useForm();
   const [formState, setFormState] = useState<
-    "initial" | "input" | "submitting"
+    "initial" | "input" | "submitting" | "retry"
   >("initial");
   const submitInputRef = useRef<HTMLInputElement>(null);
 
   const factor = flowState.context.config.factor;
-  const { title, message } = getAuthenticatingMessage(
-    factor,
-    formState === "submitting"
-  );
+  const { title, message } = getAuthenticatingMessage(factor, formState);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (e) => {
@@ -104,7 +101,7 @@ export const OTPState = ({ flowState }: Props) => {
   );
 
   const handleRetry = () => {
-    setFormState("submitting");
+    setFormState("retry");
     flowState.retry();
   };
 
@@ -144,9 +141,9 @@ export const OTPState = ({ flowState }: Props) => {
           <ErrorMessage name="otp" />
         </form>
       )}
-      {formState === "submitting" ? (
-        <Loader />
-      ) : (
+      {formState === "submitting" && <Loader />}
+      {formState === "retry" && <EmailIcon />}
+      {formState === "input" && (
         // fallback to prevent layout shift
         <Delayed delayMs={3000} fallback={<div style={{ height: 16 }} />}>
           <RetryPrompt onRetry={handleRetry} />

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -69,7 +69,7 @@ export const OTPState = ({ flowState }: Props) => {
   useEffect(() => {
     const handler = () => {
       setError("otp", {
-        message: text["authenticating.itpInput.submit.error"],
+        message: text["authenticating.otpInput.submit.error"],
       });
       values["otp"] = "";
     };

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -95,12 +95,12 @@ export const OTPState = ({ flowState }: Props) => {
         },
       };
 
-      if (!values["otp"] && hasError("otp")) {
+      if (hasError("otp")) {
         clearError("otp");
       }
       onChange(event as never);
     },
-    [clearError, hasError, registerField, text, values]
+    [clearError, hasError, registerField, text]
   );
 
   const handleRetry = () => {

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -35,6 +35,8 @@ const FactorIcon = ({ factor }: { factor: Factor }) => {
   return <Loader />;
 };
 
+const BASE_RETRY_DELAY = 2000;
+
 /**
  * Presents the user with a form to enter an OTP code.
  * Handles retries in case of submitting an incorrect OTP code.
@@ -152,8 +154,13 @@ export const OTPState = ({ flowState }: Props) => {
       ) : null}
       {formState === "input" && (
         // fallback to prevent layout shift
-        <Delayed delayMs={3000} fallback={<div style={{ height: 16 }} />}>
-          <RetryPrompt onRetry={handleRetry} />
+        <Delayed
+          delayMs={BASE_RETRY_DELAY * flowState.context.attempt}
+          fallback={<div style={{ height: 16 }} />}
+        >
+          <div className={styles.wrapper}>
+            <RetryPrompt onRetry={handleRetry} />
+          </div>
         </Delayed>
       )}
     </>

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -42,7 +42,14 @@ const FactorIcon = ({ factor }: { factor: Factor }) => {
 export const OTPState = ({ flowState }: Props) => {
   const { text } = useConfiguration();
   const { sid } = useSlashID();
-  const { values, registerField, registerSubmit } = useForm();
+  const {
+    values,
+    registerField,
+    registerSubmit,
+    setError,
+    hasError,
+    clearError,
+  } = useForm();
   const [formState, setFormState] = useState<
     "initial" | "input" | "submitting"
   >("initial");
@@ -64,6 +71,15 @@ export const OTPState = ({ flowState }: Props) => {
     [sid, values]
   );
 
+  useEffect(() => {
+    sid?.subscribe("otpIncorrectCodeSubmitted", () => {
+      setError("otp", {
+        message: text["authenticating.itpInput.submit.error"],
+      });
+      values["otp"] = "";
+    });
+  });
+
   const handleChange = useCallback(
     (otp: string) => {
       const onChange = registerField("otp", {
@@ -79,9 +95,12 @@ export const OTPState = ({ flowState }: Props) => {
         },
       };
 
+      if (!values["otp"] && hasError("otp")) {
+        clearError("otp");
+      }
       onChange(event as never);
     },
-    [registerField, text]
+    [clearError, hasError, registerField, text, values]
   );
 
   useEffect(() => {

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 
 import { Factor } from "@slashid/slashid";
-import { OtpInput } from "@slashid/react-primitives";
+import { OtpInput, Delayed } from "@slashid/react-primitives";
 
 import { useConfiguration } from "../../../hooks/use-configuration";
 import { useForm } from "../../../hooks/use-form";
@@ -103,6 +103,11 @@ export const OTPState = ({ flowState }: Props) => {
     [clearError, hasError, registerField, text, values]
   );
 
+  const handleRetry = () => {
+    setFormState("submitting");
+    flowState.retry();
+  };
+
   useEffect(() => {
     if (isValidOTPCode(values["otp"])) {
       // Automatically submit the form when the OTP code is valid
@@ -142,7 +147,10 @@ export const OTPState = ({ flowState }: Props) => {
       {formState === "submitting" ? (
         <Loader />
       ) : (
-        <RetryPrompt onRetry={() => flowState.retry()} />
+        // fallback to prevent layout shift
+        <Delayed delayMs={3000} fallback={<div style={{ height: 16 }} />}>
+          <RetryPrompt onRetry={handleRetry} />
+        </Delayed>
       )}
     </>
   );

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -69,13 +69,16 @@ export const OTPState = ({ flowState }: Props) => {
   );
 
   useEffect(() => {
-    sid?.subscribe("otpIncorrectCodeSubmitted", () => {
+    const handler = () => {
       setError("otp", {
         message: text["authenticating.itpInput.submit.error"],
       });
       values["otp"] = "";
-    });
-  });
+    };
+    sid?.subscribe("otpIncorrectCodeSubmitted", handler);
+
+    return () => sid?.unsubscribe("otpIncorrectCodeSubmitted", handler);
+  }, [setError, sid, text, values]);
 
   const handleChange = useCallback(
     (otp: string) => {

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -87,13 +87,14 @@ export const TEXT = {
   "authenticating.title.smsOtp": "Check your phone",
   "authenticating.submitting.message.smsOtp": "We are verifying the code.",
   "authenticating.submitting.title.smsOtp": "Please wait",
+  "authenticating.retry.message.smsOtp": "We are resending the OTP code...",
+  "authenticating.retry.title.smsOtp": "Please wait",
   "authenticating.message.oidc":
     "Please follow the instructions in the login screen from your SSO provider.",
   "authenticating.title.oidc": "Sign in with ",
   "authenticating.otpInput": "OTP",
   "authenticating.otpInput.submit": "Submit",
-  "authenticating.itpInput.submit.error":
-    "Incorrect OTP code submitted! Insert valid code.",
+  "authenticating.otpInput.submit.error": "Please enter a valid code",
   "success.title": "You are now authenticated!",
   "success.subtitle": "You can now close this page.",
   "error.title": "Something went wrong...",

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -90,6 +90,8 @@ export const TEXT = {
   "authenticating.title.oidc": "Sign in with ",
   "authenticating.otpInput": "OTP",
   "authenticating.otpInput.submit": "Submit",
+  "authenticating.itpInput.submit.error":
+    "Incorrect OTP code submitted! Insert valid code.",
   "success.title": "You are now authenticated!",
   "success.subtitle": "You can now close this page.",
   "error.title": "Something went wrong...",

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -80,6 +80,8 @@ export const TEXT = {
   "authenticating.title.emailOtp": "Check your email",
   "authenticating.submitting.message.emailOtp": "We are verifying the code.",
   "authenticating.submitting.title.emailOtp": "Please wait",
+  "authenticating.retry.message.emailOtp": "We are resending the OTP code...",
+  "authenticating.retry.title.emailOtp": "Please wait",
   "authenticating.message.smsOtp":
     "We have sent you a code via text. Please insert it here.",
   "authenticating.title.smsOtp": "Check your phone",


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1421)
[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1529)

Changes:
 - Create <Delayed> component in `react-primitives`
 - Clear input and show error message when incorrect OTP code is submitted
 - Transition to `retry` state on retry, add corresponding UI

Testing:
 - Authenticate with OTP via email
 - Enter incorrect code
 - Input should be cleared and error message displayed
 - Resend code
 - You should see temporary retry UI
 - Once you get the code, you should see the fresh empty input state

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
