### PR TITLE
[SID-1400] Add `environment` prop to `<SlashIDProvider>`

### DIFF
--- a/.changeset/hip-dancers-rule.md
+++ b/.changeset/hip-dancers-rule.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add the `environment` prop to `<SlashIDProvider>` component

--- a/apps/react-nextjs/pages/_app.tsx
+++ b/apps/react-nextjs/pages/_app.tsx
@@ -9,7 +9,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <SlashIDProvider
       oid={oid}
       tokenStorage="localStorage"
-      baseApiUrl="https://api.sandbox.slashid.com"
+      environment="sandbox"
     >
       <Component {...pageProps} />
     </SlashIDProvider>

--- a/apps/react-remix/app/slash-id.tsx
+++ b/apps/react-remix/app/slash-id.tsx
@@ -11,7 +11,7 @@ export const SlashID = ({ children }: Props) => {
 
   return (
     <SlashIDProvider
-      baseApiUrl="https://api.sandbox.slashid.com"
+      environment="sandbox"
       oid="ORG_ID"
       tokenStorage="localStorage"
     >

--- a/apps/react-vite/src/main.tsx
+++ b/apps/react-vite/src/main.tsx
@@ -10,7 +10,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <SlashIDProvider
       oid={import.meta.env.VITE_ORG_ID}
       tokenStorage="localStorage"
-      baseApiUrl="https://api.sandbox.slashid.com"
+      environment="sandbox"
     >
       <App />
     </SlashIDProvider>

--- a/packages/react-primitives/.storybook/preview.tsx
+++ b/packages/react-primitives/.storybook/preview.tsx
@@ -18,8 +18,7 @@ export const decorators = [
       oid={import.meta.env.VITE_ORG_ID}
       themeProps={{ theme: "auto" }}
       tokenStorage="localStorage"
-      baseApiUrl="https://api.sandbox.slashid.com"
-      sdkUrl="https://cdn.sandbox.slashid.com/sdk.html"
+      environment="sandbox"
     >
       <Story />
     </SlashIDProvider>

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -18,8 +18,7 @@ export const decorators = [
       oid={import.meta.env.VITE_ORG_ID}
       themeProps={{ theme: "auto" }}
       tokenStorage="localStorage"
-      baseApiUrl="https://api.sandbox.slashid.com"
-      sdkUrl="https://cdn.sandbox.slashid.com/sdk.html"
+      environment="sandbox"
     >
       <Story />
     </SlashIDProvider>

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -8,7 +8,12 @@ import {
   useState,
 } from "react";
 
-import { PersonHandleType, SlashID, User } from "@slashid/slashid";
+import {
+  PersonHandleType,
+  SlashID,
+  SlashIDEnvironment,
+  User,
+} from "@slashid/slashid";
 import {
   ThemeProps,
   ThemeRoot,
@@ -25,7 +30,26 @@ export interface SlashIDProviderProps {
   oid: string;
   initialToken?: string;
   tokenStorage?: StorageOption;
+  /**
+   * The environment to connect to - either "production" or "sandbox".
+   * @default "production"
+   *
+   * To use a custom environment, pass an object with the following shape:
+   * @example
+   * environment: {
+   *  baseURL: "https://{YOUR_CUSTOM_API_DOMAIN}}",
+   *  sdkURL: "https://{YOUR_CUSTOM_SDK_DOMAIN}}/sdk.html"
+   * }
+   *
+   */
+  environment?: SlashIDEnvironment;
+  /**
+   * @deprecated Use the `environment` prop instead.
+   */
   baseApiUrl?: string;
+  /**
+   * @deprecated Use the `environment` prop instead.
+   */
   sdkUrl?: string;
   analyticsEnabled?: boolean;
   themeProps?: ThemeProps;
@@ -79,6 +103,7 @@ export const SlashIDProvider = ({
   oid: initialOid,
   initialToken,
   tokenStorage = "memory",
+  environment,
   baseApiUrl,
   sdkUrl,
   analyticsEnabled,
@@ -234,6 +259,7 @@ export const SlashIDProvider = ({
     if (state === "initial") {
       const slashId = new SlashID({
         oid,
+        ...(environment && { environment }),
         ...(baseApiUrl && { baseURL: baseApiUrl }),
         ...(sdkUrl && { sdkURL: sdkUrl }),
         ...(analyticsEnabled && { analyticsEnabled }),
@@ -245,7 +271,15 @@ export const SlashIDProvider = ({
 
       setState("loaded");
     }
-  }, [oid, baseApiUrl, sdkUrl, state, tokenStorage, analyticsEnabled]);
+  }, [
+    oid,
+    baseApiUrl,
+    sdkUrl,
+    state,
+    tokenStorage,
+    analyticsEnabled,
+    environment,
+  ]);
 
   useEffect(() => {
     if (state !== "loaded") {

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -293,8 +293,6 @@ root.render(
     <SlashIDProvider
       oid={import.meta.env.VITE_ORG_ID}
       themeProps={{ theme: "dark" }}
-      baseApiUrl="https://api.slashid.com"
-      sdkUrl="https://cdn.slashid.com/sdk.html"
       tokenStorage="memory"
       analyticsEnabled
     >

--- a/packages/react/src/hooks/use-slash-id.test.tsx
+++ b/packages/react/src/hooks/use-slash-id.test.tsx
@@ -17,6 +17,19 @@ const TestComponent = () => {
   return <div>{user.ID}</div>;
 };
 
+const TestEnvironmentComponent = () => {
+  const { sid } = useSlashID();
+
+  if (!sid) return null;
+
+  return (
+    <>
+      <p>{sid.baseURL}</p>
+      <p>{sid.sdkURL}</p>
+    </>
+  );
+};
+
 describe("useSlashID", () => {
   test("should return a user instance when a valid initial token is passed to the SlashIDProvider", async () => {
     render(
@@ -28,6 +41,27 @@ describe("useSlashID", () => {
     expect.assertions(1);
     await expect(
       screen.findByText(TEST_PERSON_ID)
+    ).resolves.toBeInTheDocument();
+  });
+
+  test("should use proper custom environment", async () => {
+    const customEnv = {
+      baseURL: "https://custom.base.url",
+      sdkURL: "https://custom.sdk.url",
+    };
+
+    render(
+      <SlashIDProvider environment={customEnv} oid={TEST_ORG_ID}>
+        <TestEnvironmentComponent />
+      </SlashIDProvider>
+    );
+
+    expect.assertions(2);
+    await expect(
+      screen.findByText(customEnv.baseURL)
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(customEnv.sdkURL)
     ).resolves.toBeInTheDocument();
   });
 });

--- a/packages/react/src/hooks/use-slash-id.test.tsx
+++ b/packages/react/src/hooks/use-slash-id.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { SlashIDProvider } from "../main";
 import { useSlashID } from "./use-slash-id";
 import {
@@ -50,10 +50,12 @@ describe("useSlashID", () => {
       sdkURL: "https://custom.sdk.url",
     };
 
-    render(
-      <SlashIDProvider environment={customEnv} oid={TEST_ORG_ID}>
-        <TestEnvironmentComponent />
-      </SlashIDProvider>
+    await act(() =>
+      render(
+        <SlashIDProvider environment={customEnv} oid={TEST_ORG_ID}>
+          <TestEnvironmentComponent />
+        </SlashIDProvider>
+      )
     );
 
     expect.assertions(2);
@@ -63,5 +65,28 @@ describe("useSlashID", () => {
     await expect(
       screen.findByText(customEnv.sdkURL)
     ).resolves.toBeInTheDocument();
+  });
+
+  test("should throw en error when you pass both `environment` and deprecated URLs props", async () => {
+    const customEnv = {
+      baseURL: "https://custom.base.url",
+      sdkURL: "https://custom.sdk.url",
+    };
+
+    // prevent noise in the output
+    vi.spyOn(console, "error").mockImplementation(() => null);
+
+    expect(() =>
+      render(
+        <SlashIDProvider
+          environment={customEnv}
+          baseApiUrl="test"
+          sdkUrl="test"
+          oid={TEST_ORG_ID}
+        >
+          <TestEnvironmentComponent />
+        </SlashIDProvider>
+      )
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1400)

The Core SDK have changed the environment config API some time ago, we want to update React SDK to enable the same configuration.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
