### PR TITLE
React: add wrapper for image logo

### DIFF
--- a/.changeset/early-seals-yell.md
+++ b/.changeset/early-seals-yell.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add flex wrapper around img logo element

--- a/packages/react/src/components/form/initial/logo.tsx
+++ b/packages/react/src/components/form/initial/logo.tsx
@@ -12,11 +12,15 @@ export type Props = {
 export const Logo: React.FC<Props> = ({ logo }) => {
   if (typeof logo === "string" && logo) {
     return (
-      <img
-        className={clsx("sid-logo", "sid-logo--image", styles.logo)}
-        src={logo}
-        alt="Company logo"
-      />
+      <div className={clsx("sid-logo", "sid-logo--image", styles.logo)}>
+        <div>
+          <img
+            className={styles.logo}
+            src={logo}
+            alt="Company logo"
+          />
+        </div>
+      </div>
     );
   }
 


### PR DESCRIPTION
Add a wrapper around the `<img>` element, allowing flexbox alignment without hurting the images natural size

There is a discrepancy between the markup for img vs /id (svg) logo:
```html
<div className="[logo-classes]">
  <Logo>
</div>
```

vs

```html
<img className="[logo-classes]" />
```

In the case of `img`, it's not possible to use flex alignment CSS because there is no flex container around the logo itself.