### PR TITLE
[SID-1650]React SDK: Implement an e2e test to verify the OTP via email flow

### DIFF
--- a/packages/demo-form/src/pages/FormPage/form-page.tsx
+++ b/packages/demo-form/src/pages/FormPage/form-page.tsx
@@ -4,7 +4,10 @@ import { PageLayout } from "../../components/PageLayout";
 
 import "@slashid/react/style.css";
 
-const factors: Factor[] = [{ method: "email_link" }];
+const factors: Factor[] = [
+  { method: "email_link" },
+  { method: "otp_via_email" },
+];
 
 export function FormPage() {
   return (

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -5,7 +5,7 @@
   "description": "Tests setup for /id projects",
   "main": "index.js",
   "scripts": {
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test --debug"
   },
   "author": "",
   "license": "ISC",
@@ -18,6 +18,7 @@
     "playwright.config.ts"
   ],
   "dependencies": {
+    "@slashid/slashid": "^3.22.0",
     "cheerio": "1.0.0-rc.12",
     "dotenv": "^16.4.5",
     "mailinator-client": "^1.0.4",

--- a/packages/tests/src/email.ts
+++ b/packages/tests/src/email.ts
@@ -13,7 +13,17 @@ export type CreateTestInboxInput = {
   inboxName?: string;
 };
 
-export function createTestInbox({ inboxName }: CreateTestInboxInput = {}) {
+export type TestInbox = {
+  name: string;
+  email: string;
+  getLatestEmail: () => Promise<Message | null>;
+  getOTP: (email: Message) => Promise<string | null | undefined>;
+  getJumpPageURL: (email: Message) => Promise<string | null | undefined>;
+};
+
+export function createTestInbox({
+  inboxName,
+}: CreateTestInboxInput = {}): TestInbox {
   const config = {
     teamDomain: process.env.MAILINATOR_TEAM_DOMAIN || "",
     apiKey: process.env.MAILINATOR_API_KEY || "",
@@ -107,10 +117,15 @@ export function createTestInbox({ inboxName }: CreateTestInboxInput = {}) {
     return jumpPageLink;
   }
 
+  async function getOTP(email: Message) {
+    return email.subject.match(/\d{6}/)?.[0];
+  }
+
   return {
-    name: inboxName,
+    name,
     email: `${name}@${config.teamDomain}`,
     getLatestEmail: async () => fetchLatestEmailWithRetry(),
+    getOTP,
     getJumpPageURL: async (email: Message) => {
       const message = await fetchMessage({ messageId: email.id });
 

--- a/packages/tests/src/pom/form.ts
+++ b/packages/tests/src/pom/form.ts
@@ -1,0 +1,56 @@
+import { Locator, type Page } from "@playwright/test";
+import type { FactorMethod } from "@slashid/slashid";
+
+type FactorMethodLabel = "OTP via email" | "Email link";
+
+function getLabelFromFactorMethod(method: FactorMethod): FactorMethodLabel {
+  // @ts-expect-error add missing labels when needed
+  const methodToLabel: Record<FactorMethod, FactorMethodLabel> = {
+    otp_via_email: "OTP via email",
+    email_link: "Email link",
+  };
+
+  return methodToLabel[method];
+}
+
+export class FormPage {
+  readonly url: string = "http://localhost:3000/form";
+  readonly page: Page;
+  readonly successState: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.successState = this.page.getByTestId("sid-form-success-state");
+  }
+
+  async load() {
+    await this.page.goto(this.url);
+  }
+
+  async selectAuthMethod(method: FactorMethod) {
+    // hack alert - make sure the strings are correct
+    const label = getLabelFromFactorMethod(method);
+
+    await this.page.locator(".sid-dropdown__trigger").click();
+    await this.page.getByText(label).first().click();
+  }
+
+  async enterEmail(email: string) {
+    await this.page.locator("#sid-input-email_address").fill(email);
+  }
+
+  async submitInitialForm() {
+    await this.page.getByTestId("sid-form-initial-submit-button").click();
+  }
+
+  async submitOTP(otp: string) {
+    await this.page.locator(".sid-otp-input").waitFor({ state: "visible" });
+    let index = 0;
+    for (const otpCodeInput of await this.page
+      .locator(".sid-otp-input > input")
+      .all()) {
+      await otpCodeInput.fill(otp.charAt(index));
+      index++;
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
 
   packages/tests:
     dependencies:
+      '@slashid/slashid':
+        specifier: ^3.22.0
+        version: 3.22.0
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
@@ -8688,6 +8691,23 @@ packages:
       uuid: 8.3.2
     dev: true
 
+  /@slashid/slashid@3.22.0:
+    resolution: {integrity: sha512-DVN7ciOs+RCXFpV8tIG5WFE51/O83Te3RdgmL4Zp7K9/dzGXB3f+/ps/pDjp5CseARJL5Bp7sh+HDNFtXUGm/w==}
+    dependencies:
+      '@changesets/cli': 2.26.2
+      '@types/uuid': 8.3.4
+      changeset: 0.2.6
+      compare-versions: 6.1.0
+      docdash: 1.2.0
+      jwt-decode: 3.1.2
+      qrcode: 1.5.3
+      querystring-es3: 0.2.1
+      regenerator-runtime: 0.13.11
+      ua-parser-js: 1.0.37
+      url: 0.11.3
+      uuid: 8.3.2
+    dev: false
+
   /@storybook/addon-actions@7.0.0-rc.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-e4VXOoeejRnz+yTtPGtenAvrMtwRWO4VRxbGBHDPyMo+FOlQPC6plOrQMZ+lSRaE20J3KfTo6wSLZgnHQUQtRw==}
     peerDependencies:
@@ -12342,7 +12362,6 @@ packages:
 
   /compare-versions@6.1.0:
     resolution: {integrity: sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==}
-    dev: true
 
   /compress.js@1.2.2:
     resolution: {integrity: sha512-eIsMmzyBtPVDdPtpmPXTRB6uiLjgTXygYl0KCVVp0I/U/++YzZtEkhVTuWH97dzTxKvzAcZMFwYUHGC09BSUqg==}
@@ -20592,7 +20611,6 @@ packages:
 
   /ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}
-    dev: true
 
   /udc@1.0.1:
     resolution: {integrity: sha512-jv+D9de1flsum5QkFtBdjyppCQAdz9kTck/0xST5Vx48T9LL2BYnw0Iw77dSKDQ9KZ/PS3qPO1vfXHDpLZlxcQ==}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1650)

Added an e2e test that verifies the happy path of the `otp_via_email` flow. Added extra - implemented a page object model for the `/form` page in the demo app. If this looks good I'll refactor the existing test with this approach.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
