### PR TITLE
[SID-1667] Form loading state using the primary colour

### DIFF
--- a/.changeset/young-baboons-explode.md
+++ b/.changeset/young-baboons-explode.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Use the primary color variable for Form loading states

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -43,6 +43,7 @@ for (const filePath of filesToCheck) {
 }
 
 // Switch to the main branch and build
+execSync("git config --global --add safe.directory /__w/javascript/javascript");
 execSync("git fetch origin main:main");
 execSync("git checkout main");
 execSync("pnpm install --frozen-lockfile");

--- a/packages/react/src/components/form/authenticating/icons.tsx
+++ b/packages/react/src/components/form/authenticating/icons.tsx
@@ -1,19 +1,19 @@
 import { Email, Chat, Circle, Spinner } from "@slashid/react-primitives";
 
 export const Loader = () => (
-  <Circle>
+  <Circle variant="primary">
     <Spinner />
   </Circle>
 );
 
 export const EmailIcon = () => (
-  <Circle>
+  <Circle variant="primary">
     <Email />
   </Circle>
 );
 
 export const SmsIcon = () => (
-  <Circle>
+  <Circle variant="primary">
     <Chat />
   </Circle>
 );


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1667)

So far the `<Form>` loading state did not adapt to the primary colour, which is expected based on other use cases. This is now fixed.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have generated a `changeset` if my change affects the published packages
