### PR TITLE
[Anon fix] Extend the API with anon users instead of mutating it

### DIFF
--- a/.changeset/angry-beans-wave.md
+++ b/.changeset/angry-beans-wave.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Introduce the anonymousUser property

--- a/packages/react/src/components/groups/groups.test.tsx
+++ b/packages/react/src/components/groups/groups.test.tsx
@@ -48,7 +48,7 @@ describe("Groups", () => {
     const belongsTo = vi.fn((groups: string[]) => groups.includes("groupa"));
 
     render(
-      <TestSlashIDProvider sdkState="ready" user={anonUserWithGroups}>
+      <TestSlashIDProvider sdkState="ready" anonymousUser={anonUserWithGroups}>
         <Groups belongsTo={belongsTo}>
           <TestComponent />
         </Groups>
@@ -65,7 +65,7 @@ describe("Groups", () => {
     const belongsTo = vi.fn((groups: string[]) => groups.includes("groupa"));
 
     render(
-      <TestSlashIDProvider sdkState="ready" user={anonUserWithGroups}>
+      <TestSlashIDProvider sdkState="ready" anonymousUser={anonUserWithGroups}>
         <Groups belongsTo={belongsTo}>
           <TestComponent />
         </Groups>

--- a/packages/react/src/components/groups/index.tsx
+++ b/packages/react/src/components/groups/index.tsx
@@ -44,18 +44,20 @@ type Props = {
  * ```
  */
 export const Groups = ({ belongsTo, children }: Props) => {
-  const { user } = useSlashID();
+  const { user, anonymousUser } = useSlashID();
 
   const shouldRender = useMemo(() => {
-    if (!user) {
+    const currentUser = user || anonymousUser;
+
+    if (!currentUser) {
       return false;
     }
-    const groups = user.getGroups();
+    const groups = currentUser.getGroups();
 
     return typeof belongsTo === "string"
       ? groups.includes(belongsTo)
       : belongsTo(groups);
-  }, [user, belongsTo]);
+  }, [user, anonymousUser, belongsTo]);
 
   if (!shouldRender) {
     return null;

--- a/packages/react/src/components/logged-in/logged-in.test.tsx
+++ b/packages/react/src/components/logged-in/logged-in.test.tsx
@@ -32,7 +32,7 @@ describe("LoggedIn", () => {
 
   test("should not render children when an anonymous user exists", () => {
     render(
-      <TestSlashIDProvider user={createAnonymousTestUser()}>
+      <TestSlashIDProvider anonymousUser={createAnonymousTestUser()}>
         <LoggedIn>
           <TestComponent />
         </LoggedIn>

--- a/packages/react/src/components/logged-out/logged-out.test.tsx
+++ b/packages/react/src/components/logged-out/logged-out.test.tsx
@@ -39,7 +39,7 @@ describe("LoggedOut", () => {
     const text = faker.lorem.sentence();
 
     render(
-      <TestSlashIDProvider user={createAnonymousTestUser()} sdkState="ready">
+      <TestSlashIDProvider anonymousUser={createAnonymousTestUser()} sdkState="ready">
         <LoggedOut>
           <TestComponent text={text} />
         </LoggedOut>

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -24,7 +24,7 @@ import {
 import { LogIn, MFA, Recover } from "../domain/types";
 import { SDKState } from "../domain/sdk-state";
 import { applyMiddleware } from "../middleware";
-import { userIsAnonymous } from "../utils/anonymous";
+import { isAnonymous } from "../domain/user";
 import { sequence } from "../components/utils";
 
 export type StorageOption = "memory" | "localStorage" | "cookie";
@@ -75,7 +75,8 @@ export interface SlashIDProviderProps {
 
 export interface ISlashIDContext {
   sid: SlashID | undefined;
-  user: User | AnonymousUser | undefined;
+  user: User | undefined;
+  anonymousUser: AnonymousUser | undefined;
   sdkState: SDKState;
   logOut: () => undefined;
   logIn: LogIn;
@@ -88,6 +89,7 @@ export interface ISlashIDContext {
 export const initialContextValue = {
   sid: undefined,
   user: undefined,
+  anonymousUser: undefined,
   sdkState: "initial" as const,
   logOut: () => undefined,
   logIn: () => Promise.reject("NYI"),
@@ -131,7 +133,10 @@ export const SlashIDProvider = ({
   const [oid, setOid] = useState(initialOid);
   const [token, setToken] = useState(initialToken);
   const [state, setState] = useState<SDKState>(initialContextValue.sdkState);
-  const [user, setUser] = useState<User | AnonymousUser | undefined>(undefined);
+  const [user, setUser] = useState<User | undefined>(undefined);
+  const [anonymousUser, setAnonymousUser] = useState<AnonymousUser | undefined>(
+    undefined
+  );
   const storageRef = useRef<Storage | undefined>(undefined);
   const sidRef = useRef<SlashID | undefined>(undefined);
 
@@ -153,7 +158,7 @@ export const SlashIDProvider = ({
   );
 
   const storeUser = useCallback(
-    (newUser: User | AnonymousUser) => {
+    (newUser: User) => {
       if (state === "initial") {
         return;
       }
@@ -174,12 +179,40 @@ export const SlashIDProvider = ({
     [state, __switchOrganizationInContext, oid]
   );
 
+  const storeAnonymousUser = useCallback(
+    (anonUser: AnonymousUser) => {
+      if (!anonymousUsersEnabled || state === "initial") {
+        return;
+      }
+
+      setAnonymousUser(anonUser);
+      storageRef.current?.setItem(STORAGE_TOKEN_KEY, anonUser.token);
+
+      try {
+        sidRef.current?.getAnalytics().identify(anonUser);
+      } catch {
+        // fail silently
+      }
+    },
+    [anonymousUsersEnabled, state]
+  );
+
+  const clearAnonymousUser = useCallback(() => {
+    if (!anonymousUsersEnabled || state === "initial") {
+      return;
+    }
+
+    storageRef.current?.removeItem(STORAGE_TOKEN_KEY);
+
+    setAnonymousUser(undefined);
+  }, [anonymousUsersEnabled, state]);
+
   const logOut = useCallback((): undefined => {
     if (state === "initial") {
       return;
     }
 
-    if (!user || userIsAnonymous(user)) {
+    if (!user || isAnonymous(user)) {
       return;
     }
 
@@ -220,10 +253,10 @@ export const SlashIDProvider = ({
                 value: handle.value,
               };
 
-        const shouldUpgradeUser = user && userIsAnonymous(user);
+        const shouldUpgradeUser = anonymousUsersEnabled && anonymousUser;
 
         if (shouldUpgradeUser) {
-          const upgradedUser = await user
+          const upgradedUser = await anonymousUser
             // @ts-expect-error TODO make the identifier optional
             .id(identifier, factor)
             .then(async (user) => {
@@ -242,6 +275,10 @@ export const SlashIDProvider = ({
             return applyMiddleware({ user, sid, middleware });
           });
 
+        if (anonymousUsersEnabled && shouldUpgradeUser) {
+          clearAnonymousUser();
+        }
+
         storeUser(newUser);
 
         return newUser;
@@ -250,12 +287,20 @@ export const SlashIDProvider = ({
         throw e;
       }
     },
-    [state, storeUser, user, oid, logOut]
+    [
+      state,
+      anonymousUsersEnabled,
+      anonymousUser,
+      oid,
+      storeUser,
+      clearAnonymousUser,
+      logOut,
+    ]
   );
 
   const mfa = useCallback<MFA>(
     async ({ handle, factor }) => {
-      if (user && userIsAnonymous(user)) {
+      if (anonymousUsersEnabled && anonymousUser) {
         console.warn(
           "Anonymous users cannot perform MFA, please log in first."
         );
@@ -271,7 +316,7 @@ export const SlashIDProvider = ({
       storeUser(userAfterMfa);
       return userAfterMfa;
     },
-    [state, user, storeUser]
+    [anonymousUsersEnabled, anonymousUser, state, user, storeUser]
   );
 
   /**
@@ -343,14 +388,14 @@ export const SlashIDProvider = ({
       if (newUser.anonymous) {
         const anonUser = new AnonymousUser(token, sid);
 
-        storeUser(anonUser);
+        storeAnonymousUser(anonUser);
         return anonUser;
       }
 
       storeUser(newUser);
       return newUser;
     },
-    [anonymousUsersEnabled, storeUser]
+    [anonymousUsersEnabled, storeAnonymousUser, storeUser]
   );
 
   useEffect(() => {
@@ -384,6 +429,7 @@ export const SlashIDProvider = ({
 
     const loginWithTokenFromStorage = async () => {
       const tokenFromStorage = storage.getItem(STORAGE_TOKEN_KEY);
+
       const isValidToken =
         tokenFromStorage && (await validateToken(tokenFromStorage));
 
@@ -401,7 +447,7 @@ export const SlashIDProvider = ({
 
       const anonUser = await sid.createAnonymousUser();
 
-      storeUser(anonUser);
+      storeAnonymousUser(anonUser);
 
       return anonUser;
     };
@@ -426,6 +472,7 @@ export const SlashIDProvider = ({
     anonymousUsersEnabled,
     createAndStoreUserFromToken,
     state,
+    storeAnonymousUser,
     storeUser,
     token,
     validateToken,
@@ -436,6 +483,7 @@ export const SlashIDProvider = ({
       return {
         sid: undefined,
         user,
+        anonymousUser,
         sdkState: state,
         logOut,
         logIn,
@@ -449,6 +497,7 @@ export const SlashIDProvider = ({
     return {
       sid: sidRef.current!,
       user,
+      anonymousUser,
       sdkState: state,
       logOut,
       logIn,
@@ -460,6 +509,7 @@ export const SlashIDProvider = ({
   }, [
     state,
     user,
+    anonymousUser,
     logOut,
     logIn,
     mfa,

--- a/packages/react/src/context/test-providers.tsx
+++ b/packages/react/src/context/test-providers.tsx
@@ -15,6 +15,7 @@ export const TestSlashIDProvider: React.FC<TestProviderProps> = ({
   sid,
   sdkState,
   user,
+  anonymousUser,
   children,
   logIn,
   mfa,
@@ -27,12 +28,22 @@ export const TestSlashIDProvider: React.FC<TestProviderProps> = ({
       sid,
       sdkState: sdkState || "initial",
       user,
+      anonymousUser,
       recover: recover || (async () => undefined),
       ...(logIn ? { logIn } : {}),
       ...(mfa ? { mfa } : {}),
       __switchOrganizationInContext,
     }),
-    [sid, sdkState, user, logIn, mfa, recover, __switchOrganizationInContext]
+    [
+      sid,
+      sdkState,
+      user,
+      anonymousUser,
+      recover,
+      logIn,
+      mfa,
+      __switchOrganizationInContext,
+    ]
   );
 
   return (

--- a/packages/react/src/domain/user.ts
+++ b/packages/react/src/domain/user.ts
@@ -1,5 +1,5 @@
 import { BaseUser, AnonymousUser } from "@slashid/slashid";
 
-export const userIsAnonymous = (user: BaseUser): user is AnonymousUser => {
+export const isAnonymous = (user: BaseUser): user is AnonymousUser => {
   return user.anonymous && user instanceof AnonymousUser;
 };

--- a/packages/react/src/hooks/use-gdpr-consent.ts
+++ b/packages/react/src/hooks/use-gdpr-consent.ts
@@ -90,19 +90,20 @@ type UseGDPRConsent = () => {
  * @returns {UseGDPRConsent} an object with the current consent levels and methods to update it
  */
 export const useGDPRConsent: UseGDPRConsent = () => {
-  const { user, sdkState, sid } = useSlashID();
+  const { user, anonymousUser, sdkState, sid } = useSlashID();
   const [consents, setConsents] = useState<GDPRConsent[]>([]);
   const [consentState, setConsentState] = useState<ConsentState>("initial");
 
   const storage = useMemo(() => {
-    if (user) {
-      return createApiGDPRConsentStorage(user);
+    const currentUser = user || anonymousUser;
+    if (currentUser) {
+      return createApiGDPRConsentStorage(currentUser);
     }
     if (!isBrowser()) {
       return;
     }
     return createLocalGDPRConsentStorage();
-  }, [user]);
+  }, [anonymousUser, user]);
 
   const fetchAndSyncGDPRConsent = useCallback(async () => {
     if (!storage || sdkState !== "ready") {

--- a/packages/react/src/tests/anonymous-users.test.tsx
+++ b/packages/react/src/tests/anonymous-users.test.tsx
@@ -24,8 +24,9 @@ describe("Anonymous users", () => {
 
     await waitFor(() => expect(result.current.sdkState).toBe("ready"));
 
-    expect(result.current.user).toBeDefined();
-    expect(result.current.user?.anonymous).toBe(true);
+    expect(result.current.user).not.toBeDefined();
+    expect(result.current.anonymousUser).toBeDefined();
+    expect(result.current.anonymousUser?.anonymous).toBe(true);
 
     unmount();
   });
@@ -45,6 +46,7 @@ describe("Anonymous users", () => {
     await waitFor(() => expect(result.current.sdkState).toBe("ready"));
 
     expect(result.current.user).toBeUndefined();
+    expect(result.current.anonymousUser).toBeUndefined();
 
     unmount();
   });
@@ -66,8 +68,9 @@ describe("Anonymous users", () => {
 
     await waitFor(() => expect(result.current.sdkState).toBe("ready"));
 
-    expect(result.current.user).toBeDefined();
-    expect(result.current.user?.ID).toBe(anonUser.ID);
+    expect(result.current.user).not.toBeDefined();
+    expect(result.current.anonymousUser).toBeDefined();
+    expect(result.current.anonymousUser?.ID).toBe(anonUser.ID);
 
     unmount();
     localStorage.clear();
@@ -93,8 +96,9 @@ describe("Anonymous users", () => {
 
     await waitFor(() => expect(result.current.sdkState).toBe("ready"));
 
-    expect(result.current.user).toBeDefined();
-    expect(result.current.user?.ID).toBe(anonUser.ID);
+    expect(result.current.user).not.toBeDefined();
+    expect(result.current.anonymousUser).toBeDefined();
+    expect(result.current.anonymousUser?.ID).toBe(anonUser.ID);
 
     unmount();
   });
@@ -120,8 +124,9 @@ describe("Anonymous users", () => {
 
     await waitFor(() => expect(result.current.sdkState).toBe("ready"));
 
-    expect(result.current.user).toBeDefined();
-    expect(result.current.user?.ID).toBe(anonUser.ID);
+    expect(result.current.user).not.toBeDefined();
+    expect(result.current.anonymousUser).toBeDefined();
+    expect(result.current.anonymousUser?.ID).toBe(anonUser.ID);
 
     unmount();
   });


### PR DESCRIPTION
## Anon users API - extension

In this version of the anonymous users API, anon users are exposed through the additional `anonymous` user property of the `useSlashID` hook.

If we choose this solution, we also need to update the docs as the API is different.
