### PR TITLE
[SID-1669] React SDK: fix person identified event being fired twice

### DIFF
--- a/.changeset/modern-bottles-return.md
+++ b/.changeset/modern-bottles-return.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Prevent the person identified being fired twice


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1669)

Up until now any time we stored the user in the React SDK context we also triggered the `person identified` event in the core SDK analytics. This resulted with duplicate events being fired, as the analytics internally already subscribed to the core SDK events so they were being tracked internally.

To fix this, only the function responsible for creating a user object from a stored token triggers this event from the React SDK - all other cases are covered in the core SDK.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
