### PR TITLE
[SID-1699] Granular error states: user with a no password set + no reachable handle

### DIFF
--- a/.changeset/twenty-parrots-tie.md
+++ b/.changeset/twenty-parrots-tie.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Add special handling for the no password set error

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.24.0-username.2",
+    "@slashid/slashid": "3.24.0-username.3",
     "@storybook/addon-essentials": "7.0.0-rc.2",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/src/components/form/authenticating/password.tsx
+++ b/packages/react/src/components/form/authenticating/password.tsx
@@ -34,7 +34,10 @@ const PasswordRecoveryPrompt = ({
   const { text } = useConfiguration();
 
   return (
-    <div className={styles.passwordRecoveryPrompt}>
+    <div
+      data-testid="sid-form-authenticating-recover-prompt"
+      className={styles.passwordRecoveryPrompt}
+    >
       <Text
         variant={{ size: "sm", color: "tertiary", weight: "semibold" }}
         t="authenticating.verifyPassword.recover.prompt"
@@ -42,7 +45,7 @@ const PasswordRecoveryPrompt = ({
       <LinkButton
         className={sprinkles({ marginLeft: "1" })}
         type="button"
-        testId="sid-form-authenticating-retry-button"
+        testId="sid-form-authenticating-recover-button"
         onClick={onRecoverClick}
       >
         {text["authenticating.verifyPassword.recover.cta"]}

--- a/packages/react/src/components/form/error/index.tsx
+++ b/packages/react/src/components/form/error/index.tsx
@@ -14,7 +14,10 @@ import { Text } from "../../text";
 import { TextConfigKey } from "../../text/constants";
 import { ErrorState } from "../flow";
 import { useInternalFormContext } from "../internal-context";
-import { isNonReachableHandleTypeError } from "../../../domain/errors";
+import {
+  isNoPasswordSetError,
+  isNonReachableHandleTypeError,
+} from "../../../domain/errors";
 
 import * as styles from "./error.css";
 
@@ -28,6 +31,7 @@ type ErrorType =
   | "response"
   | "rateLimit"
   | "recoverNonReachableHandleType"
+  | "noPasswordSet"
   | "unknown";
 
 function getErrorType(error: Error): ErrorType {
@@ -41,6 +45,10 @@ function getErrorType(error: Error): ErrorType {
 
   if (isNonReachableHandleTypeError(error)) {
     return "recoverNonReachableHandleType";
+  }
+
+  if (isNoPasswordSetError(error)) {
+    return "noPasswordSet";
   }
 
   return "unknown";
@@ -60,6 +68,11 @@ function mapErrorTypeToText(errorType: ErrorType): {
       return {
         title: "error.title.recoverNonReachableHandleType",
         description: "error.subtitle.recoverNonReachableHandleType",
+      };
+    case "noPasswordSet":
+      return {
+        title: "error.title.noPasswordSet",
+        description: "error.subtitle.noPasswordSet",
       };
     default:
       return {

--- a/packages/react/src/components/form/form-error.test.tsx
+++ b/packages/react/src/components/form/form-error.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestSlashIDProvider } from "../../context/test-providers";
+import { Form } from "./form";
+import { createTestUser, inputEmail } from "../test-utils";
+import { ConfigurationProvider } from "../../main";
+
+describe("#Form -> Error state", () => {
+  test("should show the error state if login fails", async () => {
+    const logInMock = vi.fn(() => Promise.reject("login error"));
+    const user = userEvent.setup();
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+        <Form />
+      </TestSlashIDProvider>
+    );
+
+    inputEmail("valid@email.com");
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(logInMock).rejects.toMatch("login error");
+    await expect(
+      screen.findByTestId("sid-form-error-state")
+    ).resolves.toBeInTheDocument();
+  });
+
+  test("should allow going back to the initial state if login fails", async () => {
+    const logInMock = vi.fn(() => Promise.reject("login error"));
+    const user = userEvent.setup();
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+        <Form />
+      </TestSlashIDProvider>
+    );
+
+    inputEmail("valid@email.com");
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(logInMock).rejects.toMatch("login error");
+    await expect(
+      screen.findByTestId("sid-form-error-state")
+    ).resolves.toBeInTheDocument();
+
+    const cancelButton = await screen.findByTestId(
+      "sid-form-authenticating-cancel-button"
+    );
+    user.click(cancelButton);
+
+    await expect(
+      screen.findByTestId("sid-form-initial-state")
+    ).resolves.toBeInTheDocument();
+  });
+
+  test("should allow a retry if login fails", async () => {
+    let loginShouldSucceed = false;
+    const logInMock = vi.fn(() => {
+      if (!loginShouldSucceed) return Promise.reject("login error");
+      return Promise.resolve(createTestUser());
+    });
+    const user = userEvent.setup();
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+        <Form />
+      </TestSlashIDProvider>
+    );
+
+    inputEmail("valid@email.com");
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(logInMock).rejects.toMatch("login error");
+    await expect(
+      screen.findByTestId("sid-form-error-state")
+    ).resolves.toBeInTheDocument();
+
+    const retryButton = await screen.findByTestId(
+      "sid-form-error-retry-button"
+    );
+
+    loginShouldSucceed = true;
+    user.click(retryButton);
+
+    await expect(
+      screen.findByTestId("sid-form-authenticating-state")
+    ).resolves.toBeInTheDocument();
+
+    await expect(
+      screen.findByTestId("sid-form-success-state")
+    ).resolves.toBeInTheDocument();
+  });
+});
+
+describe("#Form -> Error state -> Contact support", () => {
+  test("should not show the contact support CTA if the supportURL is not set", async () => {
+    const logInMock = vi.fn(() => Promise.reject("login error"));
+    const user = userEvent.setup();
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+        <ConfigurationProvider supportURL={undefined}>
+          <Form />
+        </ConfigurationProvider>
+      </TestSlashIDProvider>
+    );
+
+    inputEmail("valid@email.com");
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(logInMock).rejects.toMatch("login error");
+    await expect(
+      screen.findByTestId("sid-form-error-state")
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("sid-form-error-contact-support")
+    ).not.toBeInTheDocument();
+  });
+
+  test("should show the contact support CTA if the supportURL is a valid URL", async () => {
+    const logInMock = vi.fn(() => Promise.reject("login error"));
+    const user = userEvent.setup();
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+        <ConfigurationProvider supportURL="https://www.test.com">
+          <Form />
+        </ConfigurationProvider>
+      </TestSlashIDProvider>
+    );
+
+    inputEmail("valid@email.com");
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(logInMock).rejects.toMatch("login error");
+    await expect(
+      screen.findByTestId("sid-form-error-state")
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByTestId("sid-form-error-support-prompt")
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -247,17 +247,18 @@ describe("#Form", () => {
       screen.findByTestId("sid-form-success-state")
     ).resolves.toBeInTheDocument();
 
-    expect(onSuccess).toBeCalledTimes(1);
-    expect(onSuccess).toBeCalledWith(testUser);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(testUser);
   });
 
-  test("should show the error state if login fails", async () => {
-    const logInMock = vi.fn(() => Promise.reject("login error"));
+  test("should call the onError callback if provided on a failed login", async () => {
+    const logInMock = vi.fn(() => Promise.reject(new Error("login error")));
     const user = userEvent.setup();
+    const onError = vi.fn();
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <Form onError={onError} />
       </TestSlashIDProvider>
     );
 
@@ -265,78 +266,11 @@ describe("#Form", () => {
 
     user.click(screen.getByTestId("sid-form-initial-submit-button"));
 
-    await expect(logInMock).rejects.toMatch("login error");
-    await expect(
-      screen.findByTestId("sid-form-error-state")
-    ).resolves.toBeInTheDocument();
-  });
-
-  test("should allow going back to the initial state if login fails", async () => {
-    const logInMock = vi.fn(() => Promise.reject("login error"));
-    const user = userEvent.setup();
-
-    render(
-      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
-      </TestSlashIDProvider>
-    );
-
-    inputEmail("valid@email.com");
-
-    user.click(screen.getByTestId("sid-form-initial-submit-button"));
-
-    await expect(logInMock).rejects.toMatch("login error");
     await expect(
       screen.findByTestId("sid-form-error-state")
     ).resolves.toBeInTheDocument();
 
-    const cancelButton = await screen.findByTestId(
-      "sid-form-authenticating-cancel-button"
-    );
-    user.click(cancelButton);
-
-    await expect(
-      screen.findByTestId("sid-form-initial-state")
-    ).resolves.toBeInTheDocument();
-  });
-
-  test("should allow a retry if login fails", async () => {
-    let loginShouldSucceed = false;
-    const logInMock = vi.fn(() => {
-      if (!loginShouldSucceed) return Promise.reject("login error");
-      return Promise.resolve(createTestUser());
-    });
-    const user = userEvent.setup();
-
-    render(
-      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
-      </TestSlashIDProvider>
-    );
-
-    inputEmail("valid@email.com");
-
-    user.click(screen.getByTestId("sid-form-initial-submit-button"));
-
-    await expect(logInMock).rejects.toMatch("login error");
-    await expect(
-      screen.findByTestId("sid-form-error-state")
-    ).resolves.toBeInTheDocument();
-
-    const retryButton = await screen.findByTestId(
-      "sid-form-error-retry-button"
-    );
-
-    loginShouldSucceed = true;
-    user.click(retryButton);
-
-    await expect(
-      screen.findByTestId("sid-form-authenticating-state")
-    ).resolves.toBeInTheDocument();
-
-    await expect(
-      screen.findByTestId("sid-form-success-state")
-    ).resolves.toBeInTheDocument();
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/react/src/components/test-utils.ts
+++ b/packages/react/src/components/test-utils.ts
@@ -226,3 +226,61 @@ export class MockSlashID extends SlashID {
 }
 
 type GenericHandler = Handler<PublicReadEvents[keyof PublicReadEvents]>;
+
+/** Promise resolve() callback */
+type Resolver<T> = (value: T | PromiseLike<T>) => void;
+
+/** Promise reject() callback */
+type Rejecter = (reason?: unknown) => void;
+
+/**
+ * Deferred promise that can be resolved or rejected externally
+ */
+export default class Deferred<T> extends Promise<T> {
+  /** The resolve() callback in the inner promise */
+  private readonly resolver: Resolver<T>;
+
+  /** The reject() callback in the inner promise */
+  private readonly rejecter: Rejecter;
+
+  /**
+   * Creates a new Deferred promise
+   */
+  public constructor(
+    executor?: (resolve: Resolver<T>, reject: Rejecter) => void
+  ) {
+    // Store the resolver and rejecter in a local variable first
+    // because we're only allowed to access `this` after `super()`
+    // has been called.
+    let resolver: Resolver<T>;
+    let rejecter: Rejecter;
+
+    super((resolve, reject) => {
+      resolver = resolve;
+      rejecter = reject;
+
+      if (executor !== undefined) {
+        executor(resolve, reject);
+      }
+    });
+
+    // These values will be initialised because the Promise callback
+    // in `super()` runs immediately.
+    this.resolver = resolver!;
+    this.rejecter = rejecter!;
+  }
+
+  /**
+   * Resolves the Deferred promise
+   */
+  public resolve(value: T): void {
+    this.resolver(value);
+  }
+
+  /**
+   * Rejects the Deferred promise
+   */
+  public reject(reason?: unknown): void {
+    this.rejecter(reason);
+  }
+}

--- a/packages/react/src/components/test-utils.ts
+++ b/packages/react/src/components/test-utils.ts
@@ -227,31 +227,20 @@ export class MockSlashID extends SlashID {
 
 type GenericHandler = Handler<PublicReadEvents[keyof PublicReadEvents]>;
 
-/** Promise resolve() callback */
 type Resolver<T> = (value: T | PromiseLike<T>) => void;
-
-/** Promise reject() callback */
 type Rejecter = (reason?: unknown) => void;
 
 /**
- * Deferred promise that can be resolved or rejected externally
+ * A Promise that can be resolved or rejected from the outside.
+ * Useful in tests when you want to wait for a condition to be met.
  */
 export default class Deferred<T> extends Promise<T> {
-  /** The resolve() callback in the inner promise */
   private readonly resolver: Resolver<T>;
-
-  /** The reject() callback in the inner promise */
   private readonly rejecter: Rejecter;
 
-  /**
-   * Creates a new Deferred promise
-   */
   public constructor(
-    executor?: (resolve: Resolver<T>, reject: Rejecter) => void
+    executor: (resolve: Resolver<T>, reject: Rejecter) => void
   ) {
-    // Store the resolver and rejecter in a local variable first
-    // because we're only allowed to access `this` after `super()`
-    // has been called.
     let resolver: Resolver<T>;
     let rejecter: Rejecter;
 
@@ -259,27 +248,17 @@ export default class Deferred<T> extends Promise<T> {
       resolver = resolve;
       rejecter = reject;
 
-      if (executor !== undefined) {
-        executor(resolve, reject);
-      }
+      executor(resolve, reject);
     });
 
-    // These values will be initialised because the Promise callback
-    // in `super()` runs immediately.
     this.resolver = resolver!;
     this.rejecter = rejecter!;
   }
 
-  /**
-   * Resolves the Deferred promise
-   */
   public resolve(value: T): void {
     this.resolver(value);
   }
 
-  /**
-   * Rejects the Deferred promise
-   */
   public reject(reason?: unknown): void {
     this.rejecter(reason);
   }

--- a/packages/react/src/components/test-utils.ts
+++ b/packages/react/src/components/test-utils.ts
@@ -239,7 +239,7 @@ export default class Deferred<T> extends Promise<T> {
   private readonly rejecter: Rejecter;
 
   public constructor(
-    executor: (resolve: Resolver<T>, reject: Rejecter) => void
+    executor?: (resolve: Resolver<T>, reject: Rejecter) => void
   ) {
     let resolver: Resolver<T>;
     let rejecter: Rejecter;
@@ -248,7 +248,9 @@ export default class Deferred<T> extends Promise<T> {
       resolver = resolve;
       rejecter = reject;
 
-      executor(resolve, reject);
+      if (executor) {
+        executor(resolve, reject);
+      }
     });
 
     this.resolver = resolver!;

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -125,7 +125,9 @@ export const TEXT = {
     "Your request has been rate limited. Please try again later.",
   "error.title.recoverNonReachableHandleType": "Cannot recover account",
   "error.subtitle.recoverNonReachableHandleType":
-    "Please use an email address or a phone number to recover your account.",
+  "Please use an email address or a phone number to recover your account.",
+  "error.title.noPasswordSet": "No password set",
+  "error.subtitle.noPasswordSet": "Please contact support to set a password",
   "error.retry": "Try again",
   "error.contactSupport.prompt": "Need help?",
   "error.contactSupport.cta": "Contact support",

--- a/packages/react/src/context/config-context.tsx
+++ b/packages/react/src/context/config-context.tsx
@@ -2,6 +2,7 @@ import { createContext, ReactNode, useMemo } from "react";
 import { SlashID, TextProvider } from "@slashid/react-primitives";
 import { TEXT, TextConfig } from "../components/text/constants";
 import { FactorConfiguration } from "../domain/types";
+import { urlValidator } from "../utils/css-validation";
 
 export type Logo = string | React.ReactNode;
 
@@ -43,6 +44,7 @@ type Props = {
 
 export const ConfigurationProvider: React.FC<Props> = ({
   text,
+  supportURL,
   children,
   ...props
 }) => {
@@ -51,8 +53,12 @@ export const ConfigurationProvider: React.FC<Props> = ({
       ...initialContextValue,
       ...props,
       text: text ? { ...TEXT, ...text } : initialContextValue.text,
+      supportURL:
+        supportURL && urlValidator(supportURL)
+          ? supportURL
+          : initialContextValue.supportURL,
     };
-  }, [props, text]);
+  }, [props, supportURL, text]);
 
   return (
     <ConfigurationContext.Provider value={contextValue}>

--- a/packages/react/src/domain/errors.ts
+++ b/packages/react/src/domain/errors.ts
@@ -21,17 +21,32 @@ export function ensureError(value: unknown): Error {
 
 export const ERROR_NAMES = {
   recoverNonReachableHandleType: "recoverNonReachableHandleType",
-};
+} as const;
 
-type NonReachableHandleTypeError = Error & typeof Errors.SlashIDError & {
-  name: "NonReachableHandleType";
-};
+type NonReachableHandleTypeError = Error &
+  typeof Errors.SlashIDError & {
+    name: typeof ERROR_NAMES.recoverNonReachableHandleType;
+  };
 
 export function isNonReachableHandleTypeError(
   error: Error
 ): error is NonReachableHandleTypeError {
   return (
-    error instanceof Errors.SlashIDError &&
+    Errors.isSlashIDError(error) &&
     error.name === ERROR_NAMES.recoverNonReachableHandleType
+  );
+}
+
+type NoPasswordSetError = Error &
+  typeof Errors.SlashIDError & {
+    name: typeof Errors.ERROR_NAMES.noPasswordSet;
+  };
+
+export function isNoPasswordSetError(
+  error: Error
+): error is NoPasswordSetError {
+  return (
+    Errors.isSlashIDError(error) &&
+    error.name === Errors.ERROR_NAMES.noPasswordSet
   );
 }

--- a/packages/react/src/utils/css-validation.ts
+++ b/packages/react/src/utils/css-validation.ts
@@ -49,3 +49,12 @@ export const fontFamilyValidator = (
 
   return true;
 };
+
+export const urlValidator = (input: string): boolean => {
+  try {
+    new URL(input);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.24.0-username.2
-        version: 3.24.0-username.2
+        specifier: 3.24.0-username.3
+        version: 3.24.0-username.3
       '@storybook/addon-essentials':
         specifier: 7.0.0-rc.2
         version: 7.0.0-rc.2(react-dom@18.2.0)(react@18.2.0)
@@ -8597,8 +8597,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.24.0-username.2:
-    resolution: {integrity: sha512-HnzNtz6cdqKJnPGauUr2Wg6mw9O9pRfrQNfz+mQr//z77DMp6l2ZoK/laB7x01JDl+81UwxQEza7WGenTuECXg==}
+  /@slashid/slashid@3.24.0-username.3:
+    resolution: {integrity: sha512-Ii6G0f2SH5fOnhIDgG6o9Bb4R6bMBsFqDWoCcV7ZbgYJlnazfbiYj2nWZrBBgveQ5RXLSFfmW1yuiEg78ZcehQ==}
     dependencies:
       '@changesets/cli': 2.26.2
       '@types/uuid': 8.3.4


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1699)

When a user that was created with username only (eg no reachable handles) tries to sign in with a password, they shouldn't be able to set a password in case they haven't had one to start with.

This throws a specific error type that the React SDK picks up and renders the error state of the form accordingly.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have generated a `changeset` if my change affects the published packages
