### PR TITLE
[Hotfix] Fix the circ dep in react-primitives

### DIFF
--- a/.changeset/thick-walls-protect.md
+++ b/.changeset/thick-walls-protect.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react-primitives": patch
+---
+
+Fix the circular dependency in the read only field CSS file

--- a/packages/react-primitives/src/components/read-only-field/read-only-field.css.ts
+++ b/packages/react-primitives/src/components/read-only-field/read-only-field.css.ts
@@ -1,5 +1,5 @@
 import { style } from "@vanilla-extract/css";
-import { theme, publicVariables } from "../../main";
+import { theme, publicVariables } from "../../theme/theme.css";
 
 export const wrapper = style({
   position: "relative",


### PR DESCRIPTION
Fixing a circular dependency in `react-primitives`
