### PR TITLE
[SID-1561] Display handle value in authenticating state

### DIFF
--- a/.changeset/dirty-vans-laugh.md
+++ b/.changeset/dirty-vans-laugh.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Display handles in authenticating state messages

--- a/.changeset/good-spiders-wash.md
+++ b/.changeset/good-spiders-wash.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Add stable CSS class names to form icons

--- a/packages/react/src/components/form/authenticating/icons.tsx
+++ b/packages/react/src/components/form/authenticating/icons.tsx
@@ -1,19 +1,27 @@
 import { Email, Chat, Circle, Spinner } from "@slashid/react-primitives";
 
 export const Loader = () => (
-  <Circle variant="primary" testId="sid-loader-icon">
+  <Circle
+    variant="primary"
+    testId="sid-loader-icon"
+    className="sid-form-loader-icon"
+  >
     <Spinner />
   </Circle>
 );
 
 export const EmailIcon = () => (
-  <Circle variant="primary" testId="sid-email-icon">
+  <Circle
+    variant="primary"
+    testId="sid-email-icon"
+    className="sid-form-email-icon"
+  >
     <Email />
   </Circle>
 );
 
 export const SmsIcon = () => (
-  <Circle variant="primary" testId="sid-sms-icon">
+  <Circle variant="primary" testId="sid-sms-icon" className="sid-form-sms-icon">
     <Chat />
   </Circle>
 );

--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../../domain/handles";
 import { Text } from "../../text";
 
-import { getAuthenticatingMessage } from "./messages";
+import { getAuthenticatingMessage, getTokensFromHandle } from "./messages";
 import { OTPState } from "./otp";
 import { PasswordState } from "./password";
 import { Props } from "./authenticating.types";
@@ -18,8 +18,9 @@ import { Delayed } from "@slashid/react-primitives";
 import { BASE_RETRY_DELAY_MS } from "./authenticating.constants";
 
 const LoadingState = ({ flowState, performLogin }: Props) => {
-  const factor = flowState.context.config.factor;
+  const { factor, handle } = flowState.context.config;
   const { title, message } = getAuthenticatingMessage(factor);
+  const tokens = getTokensFromHandle(handle);
   const [showPrompt, setShowPrompt] = useState(true);
 
   useEffect(() => {
@@ -42,7 +43,11 @@ const LoadingState = ({ flowState, performLogin }: Props) => {
           </span>
         ) : undefined}
       </Text>
-      <Text t={message} variant={{ color: "contrast", weight: "semibold" }} />
+      <Text
+        t={message}
+        variant={{ color: "contrast", weight: "semibold" }}
+        tokens={tokens}
+      />
       <FactorIcon factor={factor} />
       {showPrompt && (
         <Delayed

--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../../domain/handles";
 import { Text } from "../../text";
 
-import { getAuthenticatingMessage, getTokensFromHandle } from "./messages";
+import { getAuthenticatingMessage } from "./messages";
 import { OTPState } from "./otp";
 import { PasswordState } from "./password";
 import { Props } from "./authenticating.types";
@@ -19,8 +19,7 @@ import { BASE_RETRY_DELAY_MS } from "./authenticating.constants";
 
 const LoadingState = ({ flowState, performLogin }: Props) => {
   const { factor, handle } = flowState.context.config;
-  const { title, message } = getAuthenticatingMessage(factor);
-  const tokens = getTokensFromHandle(handle);
+  const { title, message, tokens } = getAuthenticatingMessage(factor, handle);
   const [showPrompt, setShowPrompt] = useState(true);
 
   useEffect(() => {

--- a/packages/react/src/components/form/authenticating/messages.ts
+++ b/packages/react/src/components/form/authenticating/messages.ts
@@ -7,16 +7,20 @@ type AuthenticatingMessageOptions = {
   hasRetried: boolean;
 };
 
+type HandleTextTokens = Partial<
+  Record<"EMAIL_ADDRESS" | "PHONE_NUMBER", string>
+>;
+
 /**
  *  Helper function to extract phone number or email address if either is present in the handle.
  *
  * @param {Handle | undefined} handle Handle used for authentication. Can be undefined (e.g. when
  * authenticating with OIDC).
- * @returns {Record<string,string> | undefined} tokens map or undefined
+ * @returns {HandleTextTokens | undefined} tokens map or undefined
  */
-export function getTokensFromHandle(
+export function getTextTokensFromHandle(
   handle: Handle | undefined
-): Record<string, string> | undefined {
+): HandleTextTokens | undefined {
   if (handle && handle.type === "email_address") {
     return {
       EMAIL_ADDRESS: handle.value,
@@ -35,6 +39,7 @@ export function getTokensFromHandle(
 // TODO add case for password
 export function getAuthenticatingMessage(
   factor: Factor,
+  handle: Handle | undefined,
   { isSubmitting, hasRetried }: AuthenticatingMessageOptions = {
     isSubmitting: false,
     hasRetried: false,
@@ -42,6 +47,7 @@ export function getAuthenticatingMessage(
 ): {
   title: TextConfigKey;
   message: TextConfigKey;
+  tokens?: HandleTextTokens;
 } {
   switch (factor.method) {
     case "oidc":
@@ -53,29 +59,34 @@ export function getAuthenticatingMessage(
       return {
         message: "authenticating.message.webauthn",
         title: "authenticating.title.webauthn",
+        tokens: getTextTokensFromHandle(handle),
       };
 
     case "sms_link":
       return {
         message: "authenticating.message.smsLink",
         title: "authenticating.title.smsLink",
+        tokens: getTextTokensFromHandle(handle),
       };
     case "otp_via_sms": {
       if (isSubmitting && hasRetried) {
         return {
           message: "authenticating.retry.message.smsOtp",
           title: "authenticating.retry.title.smsOtp",
+          tokens: getTextTokensFromHandle(handle),
         };
       }
       if (isSubmitting) {
         return {
           message: "authenticating.submitting.message.smsOtp",
           title: "authenticating.submitting.title.smsOtp",
+          tokens: getTextTokensFromHandle(handle),
         };
       }
       return {
         message: "authenticating.message.smsOtp",
         title: "authenticating.title.smsOtp",
+        tokens: getTextTokensFromHandle(handle),
       };
     }
     case "otp_via_email":
@@ -83,23 +94,27 @@ export function getAuthenticatingMessage(
         return {
           message: "authenticating.retry.message.emailOtp",
           title: "authenticating.retry.title.emailOtp",
+          tokens: getTextTokensFromHandle(handle),
         };
       }
       if (isSubmitting) {
         return {
           message: "authenticating.submitting.message.emailOtp",
           title: "authenticating.submitting.title.emailOtp",
+          tokens: getTextTokensFromHandle(handle),
         };
       }
       return {
         message: "authenticating.message.emailOtp",
         title: "authenticating.title.emailOtp",
+        tokens: getTextTokensFromHandle(handle),
       };
     case "email_link":
     default:
       return {
         message: "authenticating.message.emailLink",
         title: "authenticating.title.emailLink",
+        tokens: getTextTokensFromHandle(handle),
       };
   }
 }

--- a/packages/react/src/components/form/authenticating/messages.ts
+++ b/packages/react/src/components/form/authenticating/messages.ts
@@ -1,10 +1,36 @@
 import { Factor } from "@slashid/slashid";
 import { TextConfigKey } from "../../text/constants";
+import { Handle } from "../../../domain/types";
 
 type AuthenticatingMessageOptions = {
   isSubmitting: boolean;
   hasRetried: boolean;
 };
+
+/**
+ *  Helper function to extract phone number or email address if either is present in the handle.
+ *
+ * @param {Handle | undefined} handle Handle used for authentication. Can be undefined (e.g. when
+ * authenticating with OIDC).
+ * @returns {Record<string,string> | undefined} tokens map or undefined
+ */
+export function getTokensFromHandle(
+  handle: Handle | undefined
+): Record<string, string> | undefined {
+  if (handle && handle.type === "email_address") {
+    return {
+      EMAIL_ADDRESS: handle.value,
+    };
+  }
+
+  if (handle && handle.type === "phone_number") {
+    return {
+      PHONE_NUMBER: handle.value,
+    };
+  }
+
+  return undefined;
+}
 
 // TODO add case for password
 export function getAuthenticatingMessage(
@@ -13,7 +39,10 @@ export function getAuthenticatingMessage(
     isSubmitting: false,
     hasRetried: false,
   }
-): { title: TextConfigKey; message: TextConfigKey } {
+): {
+  title: TextConfigKey;
+  message: TextConfigKey;
+} {
   switch (factor.method) {
     case "oidc":
       return {

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -13,7 +13,7 @@ import { useConfiguration } from "../../../hooks/use-configuration";
 import { useForm } from "../../../hooks/use-form";
 import { useSlashID } from "../../../main";
 import { Props } from "./authenticating.types";
-import { getAuthenticatingMessage } from "./messages";
+import { getAuthenticatingMessage, getTokensFromHandle } from "./messages";
 import { OTP_CODE_LENGTH, isValidOTPCode } from "./validation";
 import { ErrorMessage } from "../error-message";
 import { Text } from "../../text";
@@ -50,12 +50,13 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
   >("initial");
   const submitInputRef = useRef<HTMLInputElement>(null);
 
-  const factor = flowState.context.config.factor;
+  const { factor, handle } = flowState.context.config;
   const hasRetried = flowState.context.attempt > 1;
   const { title, message } = getAuthenticatingMessage(factor, {
     isSubmitting: formState === "submitting",
     hasRetried,
   });
+  const tokens = getTokensFromHandle(handle);
 
   useEffect(() => {
     const onOtpCodeSent = () => setFormState("input");
@@ -128,7 +129,11 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
     <>
       <BackButton onCancel={() => flowState.cancel()} />
       <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
-      <Text t={message} variant={{ color: "contrast", weight: "semibold" }} />
+      <Text
+        t={message}
+        variant={{ color: "contrast", weight: "semibold" }}
+        tokens={tokens}
+      />
       {formState === "initial" && <FactorIcon factor={factor} />}
       {formState === "input" && (
         <form

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -13,7 +13,7 @@ import { useConfiguration } from "../../../hooks/use-configuration";
 import { useForm } from "../../../hooks/use-form";
 import { useSlashID } from "../../../main";
 import { Props } from "./authenticating.types";
-import { getAuthenticatingMessage, getTokensFromHandle } from "./messages";
+import { getAuthenticatingMessage } from "./messages";
 import { OTP_CODE_LENGTH, isValidOTPCode } from "./validation";
 import { ErrorMessage } from "../error-message";
 import { Text } from "../../text";
@@ -52,11 +52,10 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
 
   const { factor, handle } = flowState.context.config;
   const hasRetried = flowState.context.attempt > 1;
-  const { title, message } = getAuthenticatingMessage(factor, {
+  const { title, message, tokens } = getAuthenticatingMessage(factor, handle, {
     isSubmitting: formState === "submitting",
     hasRetried,
   });
-  const tokens = getTokensFromHandle(handle);
 
   useEffect(() => {
     const onOtpCodeSent = () => setFormState("input");

--- a/packages/react/src/components/form/error/error.test.tsx
+++ b/packages/react/src/components/form/error/error.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TestSlashIDProvider } from "../../../context/test-providers";
+import {
+  TestSlashIDProvider,
+  TestTextProvider,
+} from "../../../context/test-providers";
 import { Form } from "../form";
 import Deferred, {
   MockSlashID,
@@ -10,6 +13,7 @@ import Deferred, {
 } from "../../test-utils";
 import { ConfigurationProvider } from "../../../main";
 import { Errors, User } from "@slashid/slashid";
+import { TEXT } from "../../text/constants";
 
 describe("#Form -> Error state", () => {
   test("should show the error state if login fails", async () => {
@@ -18,7 +22,9 @@ describe("#Form -> Error state", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <TestTextProvider text={TEXT}>
+          <Form />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 
@@ -38,7 +44,9 @@ describe("#Form -> Error state", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <TestTextProvider text={TEXT}>
+          <Form />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 
@@ -71,7 +79,9 @@ describe("#Form -> Error state", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <TestTextProvider text={TEXT}>
+          <Form />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 

--- a/packages/react/src/components/form/error/index.tsx
+++ b/packages/react/src/components/form/error/index.tsx
@@ -23,7 +23,7 @@ import * as styles from "./error.css";
 import { Retry, RetryPolicy } from "../../../domain/types";
 
 const ErrorIcon = () => (
-  <Circle variant="red" shouldAnimate={false}>
+  <Circle variant="red" shouldAnimate={false} className="sid-form-error-icon">
     <Exclamation />
   </Circle>
 );

--- a/packages/react/src/components/form/form-customisation.test.tsx
+++ b/packages/react/src/components/form/form-customisation.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, act } from "@testing-library/react";
 import { Form } from ".";
-import { TestSlashIDProvider } from "../../context/test-providers";
+import {
+  TestSlashIDProvider,
+  TestTextProvider,
+} from "../../context/test-providers";
 import { createTestUser, inputEmail } from "../test-utils";
 import { Slot } from "../slot";
 import userEvent from "@testing-library/user-event";
@@ -92,19 +95,21 @@ describe("#Form - customisation", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form>
-          <Slot name="error">
-            <Form.Error key="error slot child">
-              {({ context, retry, cancel }) => (
-                <div data-testid="custom-error-function">
-                  <h1>{context.error.message}</h1>
-                  <button onClick={() => retry("retry")}>Retry</button>
-                  <button onClick={cancel}>Cancel</button>
-                </div>
-              )}
-            </Form.Error>
-          </Slot>
-        </Form>
+        <TestTextProvider text={TEXT}>
+          <Form>
+            <Slot name="error">
+              <Form.Error key="error slot child">
+                {({ context, retry, cancel }) => (
+                  <div data-testid="custom-error-function">
+                    <h1>{context.error.message}</h1>
+                    <button onClick={() => retry("retry")}>Retry</button>
+                    <button onClick={cancel}>Cancel</button>
+                  </div>
+                )}
+              </Form.Error>
+            </Slot>
+          </Form>
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -7,7 +7,10 @@ import { TEXT } from "../text/constants";
 import { STORAGE_LAST_HANDLE_KEY } from "../../hooks/use-last-handle";
 import { createTestUser, inputEmail, MockSlashID } from "../test-utils";
 
-import { TestSlashIDProvider } from "../../context/test-providers";
+import {
+  TestSlashIDProvider,
+  TestTextProvider,
+} from "../../context/test-providers";
 import { ConfigurationProvider } from "../../context/config-context";
 
 describe("#Form", () => {
@@ -159,7 +162,9 @@ describe("#Form", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <TestTextProvider text={TEXT}>
+          <Form />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 
@@ -186,7 +191,9 @@ describe("#Form", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <TestTextProvider text={TEXT}>
+          <Form />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 
@@ -214,7 +221,9 @@ describe("#Form", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form />
+        <TestTextProvider text={TEXT}>
+          <Form />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 
@@ -235,7 +244,9 @@ describe("#Form", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form onSuccess={onSuccess} />
+        <TestTextProvider text={TEXT}>
+          <Form onSuccess={onSuccess} />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 
@@ -258,7 +269,9 @@ describe("#Form", () => {
 
     render(
       <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
-        <Form onError={onError} />
+        <TestTextProvider text={TEXT}>
+          <Form onError={onError} />
+        </TestTextProvider>
       </TestSlashIDProvider>
     );
 

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -86,28 +86,30 @@ export const TEXT = {
   "authenticating.confirm": "Confirm",
   "authenticating.downloadCodes": "Download codes",
   "authenticating.message.webauthn":
-    "If you are registering for the first time, you will receive an email to verify your email address.",
+    "If you are registering for the first time, you will receive an email to verify your email address {{EMAIL_ADDRESS}}.",
   "authenticating.title.webauthn":
     "You'll be prompted to validate your login via your device",
   "authenticating.message.emailLink":
-    "We have sent you a link via email. Follow the link provided to complete your registration.",
+    "We have sent you a link via email to {{EMAIL_ADDRESS}}. Follow the link provided to complete your registration.",
   "authenticating.title.emailLink": "Check your email",
   "authenticating.message.smsLink":
-    "We have sent you a link via text. Follow the link provided to complete your registration.",
+    "We have sent you a link via text to {{PHONE_NUMBER}}. Follow the link provided to complete your registration.",
   "authenticating.title.smsLink": "Check your phone",
   "authenticating.message.emailOtp":
-    "We have sent you a code via email. Please insert it here.",
+    "We have sent you a code via email to {{EMAIL_ADDRESS}}. Please insert it here.",
   "authenticating.title.emailOtp": "Check your email",
   "authenticating.submitting.message.emailOtp": "We are verifying the code.",
   "authenticating.submitting.title.emailOtp": "Please wait",
-  "authenticating.retry.message.emailOtp": "We are resending the OTP code...",
+  "authenticating.retry.message.emailOtp":
+    "We are resending the OTP code to {{EMAIL_ADDRESS}}...",
   "authenticating.retry.title.emailOtp": "Please wait",
   "authenticating.message.smsOtp":
-    "We have sent you a code via text. Please insert it here.",
+    "We have sent you a code via text to {{PHONE_NUMBER}}. Please insert it here.",
   "authenticating.title.smsOtp": "Check your phone",
   "authenticating.submitting.message.smsOtp": "We are verifying the code.",
   "authenticating.submitting.title.smsOtp": "Please wait",
-  "authenticating.retry.message.smsOtp": "We are resending the OTP code...",
+  "authenticating.retry.message.smsOtp":
+    "We are resending the OTP code to {{PHONE_NUMBER}}...",
   "authenticating.retry.title.smsOtp": "Please wait",
   "authenticating.message.oidc":
     "Please follow the instructions in the login screen from your SSO provider.",

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -86,7 +86,7 @@ export const TEXT = {
   "authenticating.confirm": "Confirm",
   "authenticating.downloadCodes": "Download codes",
   "authenticating.message.webauthn":
-    "If you are registering for the first time, you will receive an email to verify your email address {{EMAIL_ADDRESS}}.",
+    "If you are registering for the first time, you will receive an email at {{EMAIL_ADDRESS}} to verify your email address.",
   "authenticating.title.webauthn":
     "You'll be prompted to validate your login via your device",
   "authenticating.message.emailLink":

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -323,11 +323,11 @@ root.render(
       themeProps={{ theme: "dark" }}
       tokenStorage="localStorage"
       analyticsEnabled
-      anonymousUsersEnabled
-      environment={{
-        baseURL: "https://api.slashid.local",
-        sdkURL: "https://jump.slashid.local/sdk.html"
-      }}
+      // anonymousUsersEnabled
+      // environment={{
+      //   baseURL: "https://api.slashid.local",
+      //   sdkURL: "https://jump.slashid.local/sdk.html"
+      // }}
     >
       <LogOut />
       <div className="layout">


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1561)

Sometimes people make typos when trying to sign up with SlashID. Once you submit the form, you can't see the exact handle you just typed in anymore. We want to add this information, so that people can see if they made a typo in case they don't receive an email or sms.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
