### PR TITLE
[SID-1742] React SDK: Send FlowCancelled event when the flow is cancelled

### DIFF
--- a/.changeset/dull-baboons-search.md
+++ b/.changeset/dull-baboons-search.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Fix the issue with polling going on after flow cancellation

--- a/.changeset/violet-goats-drop.md
+++ b/.changeset/violet-goats-drop.md
@@ -1,0 +1,5 @@
+---
+"@slashid/remix": patch
+---
+
+Update the Core SDK to match React SDK dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.25.0",
+    "@slashid/slashid": "3.26.1-cancel-flow.2",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.26.1-cancel-flow.2",
+    "@slashid/slashid": "3.26.1",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -100,7 +100,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.25.0",
+    "@slashid/slashid": ">= 3.26.1",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/src/components/form/flow.ts
+++ b/packages/react/src/components/form/flow.ts
@@ -265,6 +265,7 @@ type HistoryEntry = {
 export function createFlow(opts: CreateFlowOptions = {}) {
   let logInFn: undefined | LogIn | MFA = undefined;
   let recoverFn: undefined | Recover = undefined;
+  let cancelFn: undefined | Cancel = undefined;
   let recoveryCodes: undefined | string[] = undefined;
   let observers: Observer[] = [];
   const send = (event: Event) => {
@@ -376,6 +377,10 @@ export function createFlow(opts: CreateFlowOptions = {}) {
         );
         break;
       case "sid_cancel":
+        if (typeof cancelFn === "function") {
+          cancelFn();
+        }
+
         setState(createInitialState(send), e);
         break;
       default:
@@ -398,6 +403,9 @@ export function createFlow(opts: CreateFlowOptions = {}) {
     },
     setRecover: (fn: Recover) => {
       recoverFn = fn;
+    },
+    setCancel: (fn: Cancel) => {
+      cancelFn = fn;
     },
     state,
   };

--- a/packages/react/src/components/form/useFlowState.ts
+++ b/packages/react/src/components/form/useFlowState.ts
@@ -4,7 +4,7 @@ import { useSlashID } from "../../hooks/use-slash-id";
 import { Flow, createFlow, FlowState, CreateFlowOptions } from "./flow";
 
 export function useFlowState(opts: CreateFlowOptions = {}) {
-  const { logIn, mfa, recover, user, sdkState } = useSlashID();
+  const { logIn, mfa, recover, user, sdkState, sid } = useSlashID();
   const flowRef = useRef<Flow>(createFlow(opts));
   const [state, setState] = useState<FlowState>(flowRef.current.state);
 
@@ -19,7 +19,10 @@ export function useFlowState(opts: CreateFlowOptions = {}) {
     if (sdkState !== "ready") return;
 
     flowRef.current.setRecover(recover);
-  }, [recover, sdkState]);
+    flowRef.current.setCancel(() => {
+      sid?.publish("flowCancelled", undefined);
+    });
+  }, [recover, sdkState, sid]);
 
   useEffect(() => {
     if (user && !user.anonymous) {

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -10,7 +10,7 @@
   "module": "dist/main.js",
   "dependencies": {
     "@slashid/react": "workspace:*",
-    "@slashid/slashid": "3.25.0",
+    "@slashid/slashid": "3.26.1",
     "jose": "^5.2.0",
     "url-join": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.26.1-cancel-flow.2
-        version: 3.26.1-cancel-flow.2
+        specifier: 3.26.1
+        version: 3.26.1
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8166,8 +8166,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.26.1-cancel-flow.2:
-    resolution: {integrity: sha512-XStZ8r6CWmo6O3mz2GBlia0DbHg2Nk/POilUgh/vzB+aFK05slTyu0XFTDg7jD7Om4B976UZKt0Ku9tDaYUt5w==}
+  /@slashid/slashid@3.26.1:
+    resolution: {integrity: sha512-T3MFhqg+NXoJp+53Lr8X9l3wOGcoqw2ivf8+/qHv+P9OLs0EEfkphLLT4zvb6Y8TPVAWDmtQN2fBbvzaRtpUqg==}
     dependencies:
       '@changesets/cli': 2.26.2
       '@types/uuid': 8.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.25.0
-        version: 3.25.0
+        specifier: 3.26.1-cancel-flow.2
+        version: 3.26.1-cancel-flow.2
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8164,6 +8164,24 @@ packages:
       ua-parser-js: 1.0.37
       url: 0.11.3
       uuid: 8.3.2
+    dev: false
+
+  /@slashid/slashid@3.26.1-cancel-flow.2:
+    resolution: {integrity: sha512-XStZ8r6CWmo6O3mz2GBlia0DbHg2Nk/POilUgh/vzB+aFK05slTyu0XFTDg7jD7Om4B976UZKt0Ku9tDaYUt5w==}
+    dependencies:
+      '@changesets/cli': 2.26.2
+      '@types/uuid': 8.3.4
+      changeset: 0.2.6
+      compare-versions: 6.1.0
+      docdash: 1.2.0
+      jwt-decode: 3.1.2
+      qrcode: 1.5.3
+      querystring-es3: 0.2.1
+      regenerator-runtime: 0.13.11
+      ua-parser-js: 1.0.37
+      url: 0.11.3
+      uuid: 8.3.2
+    dev: true
 
   /@storybook/addon-actions@7.6.19:
     resolution: {integrity: sha512-ATLrA5QKFJt7tIAScRHz5T3eBQ+RG3jaZk08L7gChvyQZhei8knWwePElZ7GaWbCr9BgznQp1lQUUXq/UUblAQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,8 +613,8 @@ importers:
         specifier: workspace:*
         version: link:../react
       '@slashid/slashid':
-        specifier: 3.25.0
-        version: 3.25.0
+        specifier: 3.26.1
+        version: 3.26.1
       jose:
         specifier: ^5.2.0
         version: 5.2.0
@@ -8181,7 +8181,6 @@ packages:
       ua-parser-js: 1.0.37
       url: 0.11.3
       uuid: 8.3.2
-    dev: true
 
   /@storybook/addon-actions@7.6.19:
     resolution: {integrity: sha512-ATLrA5QKFJt7tIAScRHz5T3eBQ+RG3jaZk08L7gChvyQZhei8knWwePElZ7GaWbCr9BgznQp1lQUUXq/UUblAQ==}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1742)

This PR resolves the issue of flow cancellation when the polling doesn't stop if you cancel the flow,

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
