### PR TITLE
React: expose authentication form state

### DIFF
--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -75,7 +75,9 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-export const Authenticating = ({ flowState }: Pick<Props, "flowState">) => {
+export type AuthenticatingProps = Pick<Props, "flowState">
+
+export const Authenticating = ({ flowState }: AuthenticatingProps) => {
   const factor = flowState.context.config.factor;
   const attempt = useRef(1);
   const isLoggingIn = useRef(false);

--- a/packages/react/src/components/form/index.tsx
+++ b/packages/react/src/components/form/index.tsx
@@ -1,2 +1,3 @@
 export { Form } from "./form";
 export type { Props as FormProps } from "./form";
+export { Authenticating } from './states'

--- a/packages/react/src/components/form/states.tsx
+++ b/packages/react/src/components/form/states.tsx
@@ -1,0 +1,14 @@
+import clsx from "clsx";
+import * as styles from "./form.css";
+import { AuthenticatingProps, Authenticating as AuthenticatingState } from "./authenticating";
+import { ConfigurationProvider } from "../../context/config-context";
+
+export const Authenticating = (props: AuthenticatingProps) => {
+  return (
+    <div className={clsx("sid-form", styles.form)}>
+      <ConfigurationProvider>
+        <AuthenticatingState flowState={props.flowState} />
+      </ConfigurationProvider>
+    </div>
+  )
+}

--- a/packages/react/src/dev.css
+++ b/packages/react/src/dev.css
@@ -38,3 +38,7 @@ body {
 .layout .sid-form {
   width: 480px;
 }
+
+.states .sid-form {
+  width: 480px;
+}

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -15,10 +15,12 @@ import {
   SlashIDLoaded,
   SlashIDProvider,
   useOrganizations,
-  useSlashID,
+  useSlashID
 } from "./main";
 import { defaultOrganization } from "./middleware/default-organization";
 import { Slot } from "./components/slot";
+import { AuthenticatingState } from "./components/form/flow";
+import { Authenticating } from "./components/form";
 
 const rootOid = "b6f94b67-d20f-7fc3-51df-bf6e3b82683e";
 
@@ -351,6 +353,37 @@ root.render(
             <ConfiguredDynamicFlow />
           </div>
         </div>
+      </div>
+
+      <div className="states">
+        {(() => {
+          const forcedEmailMagicLinkLoadingState: AuthenticatingState = {
+            status: "authenticating",
+            context: {
+              config: {
+                handle: {
+                  type: "email_address",
+                  value: "foo@world.com"
+                },
+                factor:  {
+                  method: "email_link"
+                }
+              },
+              attempt: 1
+            },
+            retry: () => {},
+            cancel: () => {},
+            recover: () => {},
+            logIn: () => {},
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            setRecoveryCodes: (_code: string[]) => {}
+          }
+
+          return (
+            <Authenticating flowState={forcedEmailMagicLinkLoadingState} />
+          )
+        })()}
+        
       </div>
     </SlashIDProvider>
   </React.StrictMode>

--- a/packages/react/src/main.ts
+++ b/packages/react/src/main.ts
@@ -1,5 +1,5 @@
 import { DynamicFlow } from "./components/dynamic-flow";
-import { Form } from "./components/form";
+import { Authenticating, Form } from "./components/form";
 import { Slot } from "./components/slot";
 import { GDPRConsentDialog } from "./components/gdpr-consent-dialog";
 import { Groups } from "./components/groups";
@@ -43,6 +43,10 @@ const Customisation = {
   ...validation,
 };
 
+const FormState = {
+  Authenticating
+}
+
 /**
  * TODO: think about code splitting
  */
@@ -70,6 +74,9 @@ export {
   type CssVariable,
   type CssVariableConfig,
   Customisation,
+
+  // raw states
+  FormState,
 
   // middleware
   defaultOrganization,


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1764)

This PR exposes the internal `<Authenticating>` state for advanced use cases where rendering individual states manually is necessary.

Public interface looks like this:
```
import { States } from '@slashid/react'

<States.Authenticating flowState={...} />
```