### PR TITLE
[SID-1773] React: allow line-breaks in text config 

### DIFF
--- a/.changeset/moody-eyes-sell.md
+++ b/.changeset/moody-eyes-sell.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Allow linebreaks in text config

--- a/packages/react-primitives/src/components/text/index.tsx
+++ b/packages/react-primitives/src/components/text/index.tsx
@@ -35,6 +35,11 @@ export const Text: React.FC<InternalProps> = ({
 }) => {
   const text = useText();
   const Component = as ? as : "p";
+  const raw = tokens ? interpolate(text[t], tokens) : text[t]
+  const rawWithLineBreaks = raw.replace(/\r/g, "").split(/\n/).map(txt => {
+    if (txt === "") return <br />
+    return txt
+  })
 
   return (
     <Component
@@ -45,7 +50,7 @@ export const Text: React.FC<InternalProps> = ({
         className
       )}
     >
-      {tokens ? interpolate(text[t], tokens) : text[t]}
+      {rawWithLineBreaks}
       {children ? children : null}
     </Component>
   );


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1773)

- Convert linebreaks provided in text config to `<br>`

We support cross-platform line-break characters like this:
1. Replace all carriage returns `\r` with empty string
2. Split on newline character `\n`
3. Replace split character with `<br>`
