### PR TITLE
[SID-1773] React: use css to support line breaks

### DIFF
--- a/.changeset/quiet-suits-study.md
+++ b/.changeset/quiet-suits-study.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Improve misbehaving linebreak behaviour

--- a/packages/react-primitives/src/components/text/index.tsx
+++ b/packages/react-primitives/src/components/text/index.tsx
@@ -35,14 +35,6 @@ export const Text: React.FC<InternalProps> = ({
 }) => {
   const text = useText();
   const Component = as ? as : "p";
-  const raw = (tokens ? interpolate(text[t], tokens) : text[t]) ?? ""
-  const rawWithLineBreaks = raw
-    .replace(/\r/g, "")
-    .split(/\n/)
-    .map((txt) => {
-      if (txt === "") return <br />;
-      return txt;
-    });
 
   return (
     <Component
@@ -53,7 +45,7 @@ export const Text: React.FC<InternalProps> = ({
         className
       )}
     >
-      {rawWithLineBreaks}
+      {tokens ? interpolate(text[t], tokens) : text[t]}
       {children ? children : null}
     </Component>
   );

--- a/packages/react-primitives/src/components/text/text.css.ts
+++ b/packages/react-primitives/src/components/text/text.css.ts
@@ -9,6 +9,7 @@ export const text = recipe({
     color: publicVariables.color.foreground,
     margin: 0,
     lineHeight: "100%",
+    whiteSpace: "pre-wrap"
   },
 
   variants: {


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1773)

Same as https://github.com/slashid/javascript/pull/277 but using CSS only