### PR TITLE
[SID-1779] Add class names to Form title and subtitle, fix Authenticating slot

### DIFF
--- a/.changeset/green-mugs-flash.md
+++ b/.changeset/green-mugs-flash.md
@@ -1,0 +1,6 @@
+---
+"@slashid/react": minor
+"@slashid/react-primitives": patch
+---
+
+Add stable class names to form title and subtitle in authenticating state.

--- a/packages/react-primitives/package.json
+++ b/packages/react-primitives/package.json
@@ -55,6 +55,8 @@
     "build:storybook": "storybook build",
     "lint": "eslint ./src",
     "test:types": "tsc --noEmit --emitDeclarationOnly false",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "publish:yalc": "node ./yalc.next.js && pnpm build && yalc publish"
   },
   "dependencies": {

--- a/packages/react-primitives/scripts/test-setup.js
+++ b/packages/react-primitives/scripts/test-setup.js
@@ -1,0 +1,13 @@
+import "@testing-library/jest-dom/extend-expect";
+import matchers from "@testing-library/jest-dom/matchers";
+import { Request, Response, fetch } from "cross-fetch";
+import { expect } from "vitest";
+import "vitest-canvas-mock";
+
+// extends Vitest's expect method with methods from react-testing-library
+expect.extend(matchers);
+// polyfill for browser APIs
+global.fetch = fetch;
+global.Request = Request;
+global.Response = Response;
+global.navigator.sendBeacon = () => {};

--- a/packages/react-primitives/src/components/text/index.tsx
+++ b/packages/react-primitives/src/components/text/index.tsx
@@ -34,13 +34,13 @@ export const Text: React.FC<InternalProps> = ({
   children,
 }) => {
   const text = useText();
-  const Component = as ?? "p";
+  const Component = as ? as : "p";
 
   return (
     <Component
       className={clsx(
         "sid-text",
-        `sid-text--${as}`,
+        `sid-text--${Component}`,
         styles.text(variant),
         className
       )}

--- a/packages/react-primitives/src/components/text/index.tsx
+++ b/packages/react-primitives/src/components/text/index.tsx
@@ -34,7 +34,7 @@ export const Text: React.FC<InternalProps> = ({
   children,
 }) => {
   const text = useText();
-  const Component = as ? as : "p";
+  const Component = as ?? "p";
 
   return (
     <Component

--- a/packages/react-primitives/src/components/text/text.test.tsx
+++ b/packages/react-primitives/src/components/text/text.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { Text } from "./index";
+import { interpolate } from "./interpolation";
+import { TextProvider } from "./text-context";
+
+describe("<Text>", () => {
+  test("should render the text without interpolation", () => {
+    const text = { hello: "world" };
+    render(
+      <TextProvider text={text}>
+        <Text t="hello" />
+      </TextProvider>
+    );
+
+    expect(screen.getByText("world")).toBeInTheDocument();
+  });
+
+  test("should render the text with interpolation", () => {
+    const tokens = { name: "John" };
+    const text = { hello: "Hello, {{name}}!" };
+
+    render(
+      <TextProvider text={text}>
+        <Text t="hello" tokens={tokens} />
+      </TextProvider>
+    );
+    expect(screen.getByText("Hello, John!")).toBeInTheDocument();
+  });
+});
+
+describe("interpolate", () => {
+  test("should replace placeholders with values from tokens", () => {
+    const text = "Hello, {{name}}! You are {{age}} years old.";
+    const tokens = {
+      name: "John",
+      age: "30",
+    };
+    const interpolatedText = interpolate(text, tokens);
+    expect(interpolatedText).toBe("Hello, John! You are 30 years old.");
+  });
+
+  test("should not replace placeholders if corresponding token is missing", () => {
+    const text = "Hello, {{name}}! You are {{age}} years old.";
+    const tokens = {
+      name: "John",
+    };
+    const interpolatedText = interpolate(text, tokens);
+    expect(interpolatedText).toBe("Hello, John! You are {{age}} years old.");
+  });
+
+  test("should return the original text if tokens are not provided", () => {
+    const text = "Hello, {{name}}! You are {{age}} years old.";
+    const interpolatedText = interpolate(text, {});
+    expect(interpolatedText).toBe(text);
+  });
+});

--- a/packages/react/src/components/dynamic-flow/index.tsx
+++ b/packages/react/src/components/dynamic-flow/index.tsx
@@ -5,7 +5,7 @@ import { useCallback } from "react";
 import { Handle, LoginOptions } from "../../domain/types";
 import { CreateFlowOptions } from "../form/flow";
 import { useFlowState } from "../form/useFlowState";
-import { Authenticating } from "../form/authenticating";
+import { AuthenticatingImplementation as Authenticating } from "../form/authenticating";
 import { Success } from "../form/success";
 import { Error } from "../form/error";
 
@@ -55,7 +55,7 @@ export const DynamicFlow = ({
       )}
       {flowState.status === "authenticating" && (
         <FormProvider>
-          <Authenticating />
+          <Authenticating flowState={flowState} />
         </FormProvider>
       )}
       {flowState.status === "error" && <Error />}

--- a/packages/react/src/components/dynamic-flow/index.tsx
+++ b/packages/react/src/components/dynamic-flow/index.tsx
@@ -55,7 +55,7 @@ export const DynamicFlow = ({
       )}
       {flowState.status === "authenticating" && (
         <FormProvider>
-          <Authenticating flowState={flowState} />
+          <Authenticating />
         </FormProvider>
       )}
       {flowState.status === "error" && <Error />}

--- a/packages/react/src/components/form/authenticating/authenticating.components.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.components.tsx
@@ -1,5 +1,5 @@
 import { Factor } from "@slashid/slashid";
-import { LinkButton, sprinkles } from "@slashid/react-primitives";
+import { LinkButton, TextContext, sprinkles } from "@slashid/react-primitives";
 
 import { useConfiguration } from "../../../hooks/use-configuration";
 import { Text } from "../../text";
@@ -8,6 +8,27 @@ import { EmailIcon, SmsIcon, Loader } from "./icons";
 
 import * as styles from "./authenticating.css";
 import { TextConfigKey } from "../../text/constants";
+import { useContext } from "react";
+
+/**
+ * This must be present in all authenticating states.
+ * It only renders if the text key `authenticating.subtitle` is present.
+ */
+export const AuthenticatingSubtitle = () => {
+  const { text } = useContext(TextContext);
+
+  if (!text["authenticating.subtitle"]) {
+    return null;
+  }
+
+  return (
+    <Text
+      as="p"
+      className="sid-text-authenticating-subtitle"
+      t="authenticating.subtitle"
+    />
+  );
+};
 
 export const BackButton = ({ onCancel }: { onCancel: () => void }) => {
   const { text } = useConfiguration();

--- a/packages/react/src/components/form/authenticating/authenticating.components.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.components.tsx
@@ -24,7 +24,7 @@ export const AuthenticatingSubtitle = () => {
   return (
     <Text
       as="p"
-      className="sid-text-authenticating-subtitle"
+      className="sid-form-authenticating-subtitle"
       t="authenticating.subtitle"
     />
   );

--- a/packages/react/src/components/form/authenticating/authenticating.test.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { Authenticating } from "./index";
+import { AuthenticatingState } from "../flow";
+import { TestTextProvider } from "../../../context/test-providers";
+import { TEXT } from "../../text/constants";
+
+describe("Authenticating", () => {
+  test("should render the email link authenticating state", () => {
+    const flowState: AuthenticatingState = {
+      status: "authenticating",
+      context: {
+        config: {
+          factor: {
+            method: "email_link",
+          },
+          handle: {
+            type: "email_address",
+            value: "test@mail.com",
+          },
+        },
+        attempt: 1,
+      },
+      logIn: jest.fn(),
+      retry: jest.fn(),
+      cancel: jest.fn(),
+      recover: jest.fn(),
+      setRecoveryCodes: jest.fn(),
+    };
+
+    render(
+      <TestTextProvider text={TEXT}>
+        <Authenticating flowState={flowState} />
+      </TestTextProvider>
+    );
+
+    expect(
+      screen.getByTestId("sid-form-authenticating-state")
+    ).toBeInTheDocument();
+    expect(screen.getByText(/test@mail.com/)).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/form/authenticating/authenticating.test.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { Authenticating } from "./index";
+import { AuthenticatingImplementation as Authenticating } from "./index";
 import { AuthenticatingState } from "../flow";
 import { TestTextProvider } from "../../../context/test-providers";
 import { TEXT } from "../../text/constants";

--- a/packages/react/src/components/form/authenticating/authenticating.test.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.test.tsx
@@ -4,28 +4,39 @@ import { AuthenticatingState } from "../flow";
 import { TestTextProvider } from "../../../context/test-providers";
 import { TEXT } from "../../text/constants";
 
+type CreateTestAuthenticatingStateInput = {
+  factor: AuthenticatingState["context"]["config"]["factor"];
+  handle: AuthenticatingState["context"]["config"]["handle"];
+  attempt?: AuthenticatingState["context"]["attempt"];
+};
+function createTestAuhenticatingState({
+  factor,
+  handle,
+  attempt,
+}: CreateTestAuthenticatingStateInput): AuthenticatingState {
+  return {
+    status: "authenticating",
+    context: {
+      config: {
+        factor,
+        handle,
+      },
+      attempt: attempt ?? 1,
+    },
+    logIn: jest.fn(),
+    retry: jest.fn(),
+    cancel: jest.fn(),
+    recover: jest.fn(),
+    setRecoveryCodes: jest.fn(),
+  };
+}
+
 describe("Authenticating", () => {
   test("should render the email link authenticating state", () => {
-    const flowState: AuthenticatingState = {
-      status: "authenticating",
-      context: {
-        config: {
-          factor: {
-            method: "email_link",
-          },
-          handle: {
-            type: "email_address",
-            value: "test@mail.com",
-          },
-        },
-        attempt: 1,
-      },
-      logIn: jest.fn(),
-      retry: jest.fn(),
-      cancel: jest.fn(),
-      recover: jest.fn(),
-      setRecoveryCodes: jest.fn(),
-    };
+    const flowState: AuthenticatingState = createTestAuhenticatingState({
+      factor: { method: "email_link" },
+      handle: { type: "email_address", value: "test@mail.com" },
+    });
 
     render(
       <TestTextProvider text={TEXT}>
@@ -37,5 +48,47 @@ describe("Authenticating", () => {
       screen.getByTestId("sid-form-authenticating-state")
     ).toBeInTheDocument();
     expect(screen.getByText(/test@mail.com/)).toBeInTheDocument();
+  });
+
+  test("should not render the subtitle if `authenticating.subtitle` is not set", () => {
+    const flowState: AuthenticatingState = createTestAuhenticatingState({
+      factor: { method: "email_link" },
+      handle: { type: "email_address", value: "test@mail.test" },
+    });
+
+    render(
+      <TestTextProvider text={TEXT}>
+        <Authenticating flowState={flowState} />
+      </TestTextProvider>
+    );
+
+    expect(
+      screen.getByTestId("sid-form-authenticating-state")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("sid-text-authenticating-subtitle")
+    ).toBeFalsy();
+  });
+
+  test("should render the subtitle if `authenticating.subtitle` is set", () => {
+    const flowState: AuthenticatingState = createTestAuhenticatingState({
+      factor: { method: "email_link" },
+      handle: { type: "email_address", value: "test@mail.test" },
+    });
+    const textWithAuthenticatingSubtitle = {
+      ...TEXT,
+      "authenticating.subtitle": "Authenticating subtitle",
+    };
+
+    render(
+      <TestTextProvider text={textWithAuthenticatingSubtitle}>
+        <Authenticating flowState={flowState} />
+      </TestTextProvider>
+    );
+
+    expect(
+      screen.getByTestId("sid-form-authenticating-state")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Authenticating subtitle")).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -40,7 +40,12 @@ const LoadingState = ({ flowState, performLogin }: Props) => {
   return (
     <>
       <BackButton onCancel={() => flowState.cancel()} />
-      <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }}>
+      <Text
+        className="sid-form-authenticating-title sid-form-authenticating-title-loading"
+        as="h1"
+        t={title}
+        variant={{ size: "2xl-title", weight: "bold" }}
+      >
         {factor.method === "oidc" ? (
           <span className={styles.oidcTitle}>
             {factor.options?.provider as unknown as string}

--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -120,7 +120,7 @@ export function Authenticating({ children }: AuthenticatingTemplateProps) {
 
 export type AuthenticatingProps = Pick<Props, "flowState">;
 
-const AuthenticatingImplementation = ({ flowState }: AuthenticatingProps) => {
+export const AuthenticatingImplementation = ({ flowState }: AuthenticatingProps) => {
   const factor = flowState.context.config.factor;
   const attempt = useRef(1);
   const isLoggingIn = useRef(false);

--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -9,7 +9,12 @@ import { getAuthenticatingMessage } from "./messages";
 import { OTPState } from "./otp";
 import { PasswordState } from "./password";
 import { Props } from "./authenticating.types";
-import { BackButton, FactorIcon, Prompt } from "./authenticating.components";
+import {
+  AuthenticatingSubtitle,
+  BackButton,
+  FactorIcon,
+  Prompt,
+} from "./authenticating.components";
 
 import * as styles from "./authenticating.css";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -42,6 +47,7 @@ const LoadingState = ({ flowState, performLogin }: Props) => {
           </span>
         ) : undefined}
       </Text>
+      <AuthenticatingSubtitle />
       <Text
         t={message}
         variant={{ color: "contrast", weight: "semibold" }}

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -131,7 +131,12 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
   return (
     <>
       <BackButton onCancel={() => flowState.cancel()} />
-      <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
+      <Text
+        as="h1"
+        className="sid-form-authenticating-title sid-form-authenticating-title-otp"
+        t={title}
+        variant={{ size: "2xl-title", weight: "bold" }}
+      />
       <AuthenticatingSubtitle />
       <Text
         t={message}

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -21,7 +21,11 @@ import { Text } from "../../text";
 import * as styles from "./authenticating.css";
 import { isFactorOTPEmail, isFactorOTPSms } from "../../../domain/handles";
 import { EmailIcon, SmsIcon, Loader } from "./icons";
-import { BackButton, Prompt } from "./authenticating.components";
+import {
+  AuthenticatingSubtitle,
+  BackButton,
+  Prompt,
+} from "./authenticating.components";
 import { BASE_RETRY_DELAY_MS } from "./authenticating.constants";
 
 const FactorIcon = ({ factor }: { factor: Factor }) => {
@@ -128,6 +132,7 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
     <>
       <BackButton onCancel={() => flowState.cancel()} />
       <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
+      <AuthenticatingSubtitle />
       <Text
         t={message}
         variant={{ color: "contrast", weight: "semibold" }}

--- a/packages/react/src/components/form/authenticating/password.tsx
+++ b/packages/react/src/components/form/authenticating/password.tsx
@@ -8,7 +8,7 @@ import { Text } from "../../text";
 
 import * as styles from "./authenticating.css";
 import { EmailIcon, Loader, SmsIcon } from "./icons";
-import { BackButton } from "./authenticating.components";
+import { AuthenticatingSubtitle, BackButton } from "./authenticating.components";
 import {
   Button,
   LinkButton,
@@ -259,6 +259,7 @@ export const PasswordState = ({ flowState, performLogin }: Props) => {
     <>
       <BackButton onCancel={() => flowState.cancel()} />
       <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
+      <AuthenticatingSubtitle />
       <Text
         t={message}
         variant={{ color: "contrast", weight: "semibold" }}

--- a/packages/react/src/components/form/authenticating/password.tsx
+++ b/packages/react/src/components/form/authenticating/password.tsx
@@ -8,7 +8,10 @@ import { Text } from "../../text";
 
 import * as styles from "./authenticating.css";
 import { EmailIcon, Loader, SmsIcon } from "./icons";
-import { AuthenticatingSubtitle, BackButton } from "./authenticating.components";
+import {
+  AuthenticatingSubtitle,
+  BackButton,
+} from "./authenticating.components";
 import {
   Button,
   LinkButton,
@@ -258,7 +261,12 @@ export const PasswordState = ({ flowState, performLogin }: Props) => {
   return (
     <>
       <BackButton onCancel={() => flowState.cancel()} />
-      <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
+      <Text
+        as="h1"
+        className="sid-form-authenticating-title sid-form-authenticating-title-password"
+        t={title}
+        variant={{ size: "2xl-title", weight: "bold" }}
+      />
       <AuthenticatingSubtitle />
       <Text
         t={message}

--- a/packages/react/src/components/form/authenticating/totp.tsx
+++ b/packages/react/src/components/form/authenticating/totp.tsx
@@ -8,7 +8,11 @@ import {
 import { useConfiguration } from "../../../hooks/use-configuration";
 import { useForm } from "../../../hooks/use-form";
 import { Props } from "./authenticating.types";
-import { AuthenticatingSubtitle, BackButton, Prompt } from "./authenticating.components";
+import {
+  AuthenticatingSubtitle,
+  BackButton,
+  Prompt,
+} from "./authenticating.components";
 import { Text } from "../../text";
 import { TextConfigKey } from "../../text/constants";
 import { Loader } from "./icons";
@@ -168,7 +172,12 @@ export function TOTPState({ flowState, performLogin }: Props) {
   return (
     <>
       <BackButton onCancel={() => flowState.cancel()} />
-      <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
+      <Text
+        as="h1"
+        className="sid-form-authenticating-title sid-form-authenticating-title-totp"
+        t={title}
+        variant={{ size: "2xl-title", weight: "bold" }}
+      />
       <AuthenticatingSubtitle />
       <Text t={message} variant={{ color: "contrast", weight: "semibold" }} />
       {formState === "initial" && <Loader />}

--- a/packages/react/src/components/form/authenticating/totp.tsx
+++ b/packages/react/src/components/form/authenticating/totp.tsx
@@ -8,7 +8,7 @@ import {
 import { useConfiguration } from "../../../hooks/use-configuration";
 import { useForm } from "../../../hooks/use-form";
 import { Props } from "./authenticating.types";
-import { BackButton, Prompt } from "./authenticating.components";
+import { AuthenticatingSubtitle, BackButton, Prompt } from "./authenticating.components";
 import { Text } from "../../text";
 import { TextConfigKey } from "../../text/constants";
 import { Loader } from "./icons";
@@ -169,6 +169,7 @@ export function TOTPState({ flowState, performLogin }: Props) {
     <>
       <BackButton onCancel={() => flowState.cancel()} />
       <Text as="h1" t={title} variant={{ size: "2xl-title", weight: "bold" }} />
+      <AuthenticatingSubtitle />
       <Text t={message} variant={{ color: "contrast", weight: "semibold" }} />
       {formState === "initial" && <Loader />}
       {formState === "registerAuthenticator" && (

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -64,9 +64,7 @@ export const Form = ({
       footer: showBanner ? <Footer /> : null,
       initial: status === "initial" ? <Initial /> : undefined,
       authenticating:
-        status === "authenticating" ? (
-          <Authenticating flowState={flowState} />
-        ) : undefined,
+        status === "authenticating" ? <Authenticating /> : undefined,
       success:
         status === "success" ? <Success flowState={flowState} /> : undefined,
       error: status === "error" ? <Error /> : undefined,
@@ -125,3 +123,4 @@ export const Form = ({
 
 Form.Initial = Initial;
 Form.Error = Error;
+Form.Authenticating = Authenticating;

--- a/packages/react/src/components/form/states.tsx
+++ b/packages/react/src/components/form/states.tsx
@@ -9,14 +9,14 @@
 import clsx from "clsx";
 import * as styles from "./form.css";
 import {
+  AuthenticatingImplementation,
   AuthenticatingProps,
-  Authenticating as AuthenticatingState,
 } from "./authenticating";
 
 export const Authenticating = (props: AuthenticatingProps) => {
   return (
     <div className={clsx("sid-form", styles.form)}>
-      <AuthenticatingState flowState={props.flowState} />
+      <AuthenticatingImplementation flowState={props.flowState} />
     </div>
   );
 };

--- a/packages/react/src/components/text/constants.ts
+++ b/packages/react/src/components/text/constants.ts
@@ -17,6 +17,8 @@ export const TEXT = {
   "initial.handle.username.placeholder": "Type your username",
   "initial.submit": "Continue",
   "initial.divider": "or",
+  // rendered between the form title and the UI message only if the value is not empty, regardless of the nested authentication state
+  "authenticating.subtitle": "",
   "authenticating.password.label": "Password",
   "authenticating.password.placeholder": "Type your password",
   "authenticating.passwordConfirm.label": "Confirm password",

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -217,6 +217,7 @@ const BasicForm = () => {
 const ComposedForm = () => {
   return (
     <ConfigurationProvider
+      text={{ "authenticating.subtitle": "Optional subtitle" }}
       factors={[
         { method: "webauthn" },
         { method: "email_link" },


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1779)

Form title did not have a stable class name, so I added two of them - a generic one that is always there and a conditional one that appears based on the flow type.

There were no tests for the `Text` component and the interpolation feature so I added those too.

Form can now render a `subtitle` in the `Authenticating` state, but this appears only if you specify the required text key. This was a request from GetHarley, as it lets them customise the Authenticating state without overriding it completely.

### Testing

Published beta version: `@slashid/react@1.26.0-authenticating-slot.1`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [x] I have generated a `changeset` if my change affects the published packages
