### PR TITLE
[SID-1762] React: default to 'localStorage' storage when anonymous users enabled

### DIFF
--- a/.changeset/curly-shirts-sing.md
+++ b/.changeset/curly-shirts-sing.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Storage will default to localStorage when anonymous users are enabled


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1762)

If anonymous users is turned on but storage is left default, it will be `memory` which means the anonymous users is lost each time the page refreshes.

- Set storage to `localStorage` by default if anonymous users enabled
- When new default is invoked, emit warning to set storage explicitly
- Warn if storage is explicitly set to `memory` while anonymous users enabled