### PR TITLE
[SID-1793] Add a private function to sync the SDK with external state (oid, token)

### DIFF
--- a/.changeset/eight-brooms-divide.md
+++ b/.changeset/eight-brooms-divide.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Add a private method to sync the SDK with external state (oid, token)

--- a/packages/react/src/context/test-providers.tsx
+++ b/packages/react/src/context/test-providers.tsx
@@ -21,6 +21,7 @@ export const TestSlashIDProvider: React.FC<TestProviderProps> = ({
   mfa,
   recover,
   __switchOrganizationInContext = async () => undefined,
+  __syncExternalState = async () => undefined,
 }) => {
   const value = useMemo(
     () => ({
@@ -33,6 +34,7 @@ export const TestSlashIDProvider: React.FC<TestProviderProps> = ({
       ...(logIn ? { logIn } : {}),
       ...(mfa ? { mfa } : {}),
       __switchOrganizationInContext,
+      __syncExternalState,
     }),
     [
       sid,
@@ -43,6 +45,7 @@ export const TestSlashIDProvider: React.FC<TestProviderProps> = ({
       logIn,
       mfa,
       __switchOrganizationInContext,
+      __syncExternalState,
     ]
   );
 

--- a/packages/remix/src/slashid-provider.tsx
+++ b/packages/remix/src/slashid-provider.tsx
@@ -49,6 +49,9 @@ function SlashIDProviderSSR({
       recover: () => Promise.reject("Operation not possible in this state"),
       validateToken: async () => false,
       __switchOrganizationInContext: async () => undefined,
+      __syncExternalState() {
+        throw new Error("Operation not possible in this state");
+      },
     };
   }, [
     props.analyticsEnabled,


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1793)

Only merge if needed - sync SDK with external state stores, reinitialize the SDK when token changes externally.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
