### PR TITLE
React: use type=email for email handle input

### DIFF
--- a/.changeset/wicked-spies-deliver.md
+++ b/.changeset/wicked-spies-deliver.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Set input="email" for email handle input

--- a/packages/react/src/components/dynamic-flow/handle-form.tsx
+++ b/packages/react/src/components/dynamic-flow/handle-form.tsx
@@ -113,6 +113,7 @@ export const HandleForm: React.FC<Props> = ({
           className={sprinkles({ marginTop: "4" })}
           id={`sid-input-${handleType}`}
           name={handleType}
+          type="text"
           label={text["initial.handle.username"]}
           placeholder={text["initial.handle.username.placeholder"]}
           value={values[handleType] ?? ""}
@@ -173,7 +174,7 @@ export const HandleForm: React.FC<Props> = ({
   };
 
   return (
-    <form onSubmit={registerSubmit(onSubmit)}>
+    <form onSubmit={registerSubmit(onSubmit)} noValidate>
       {shouldRenderFactorDropdown && (
         <Dropdown
           defaultValue={filteredFactors[0].method}

--- a/packages/react/src/components/dynamic-flow/handle-form.tsx
+++ b/packages/react/src/components/dynamic-flow/handle-form.tsx
@@ -89,6 +89,7 @@ export const HandleForm: React.FC<Props> = ({
           className={sprinkles({ marginTop: "4" })}
           id={`sid-input-${handleType}`}
           name={handleType}
+          type="tel"
           label={text["initial.handle.phone"]}
           placeholder={text["initial.handle.phone.placeholder"]}
           value={values[handleType] ?? ""}
@@ -132,6 +133,7 @@ export const HandleForm: React.FC<Props> = ({
         className={sprinkles({ marginTop: "4" })}
         id={`sid-input-${handleType}`}
         name={handleType}
+        type="email"
         label={text["initial.handle.email"]}
         placeholder={
           text["initial.handle.phone.email"] ||

--- a/packages/react/src/components/form/initial/controls.tsx
+++ b/packages/react/src/components/form/initial/controls.tsx
@@ -142,6 +142,7 @@ export const Controls = ({ children }: Props) => {
       <form
         data-testid="sid-form-initial-children"
         onSubmit={registerSubmit(onSubmit)}
+        noValidate
       >
         {children}
       </form>
@@ -151,6 +152,7 @@ export const Controls = ({ children }: Props) => {
     <form
       data-testid="sid-form-initial-default"
       onSubmit={registerSubmit(onSubmit)}
+      noValidate
     >
       <FormInput />
       <Submit />
@@ -379,6 +381,7 @@ const HandleInput: React.FC<PropsInternal> = ({
           className={sprinkles({ marginTop: "4" })}
           id={`sid-input-${handleType}`}
           name={handleType}
+          type="tel"
           label={text["initial.handle.phone"]}
           placeholder={text["initial.handle.phone.placeholder"]}
           value={values[handleType] ?? ""}
@@ -402,6 +405,7 @@ const HandleInput: React.FC<PropsInternal> = ({
           className={sprinkles({ marginTop: "4" })}
           id={`sid-input-${handleType}`}
           name={handleType}
+          type="text"
           label={text["initial.handle.username"]}
           placeholder={text["initial.handle.username.placeholder"]}
           value={values[handleType] ?? ""}
@@ -422,6 +426,7 @@ const HandleInput: React.FC<PropsInternal> = ({
         className={sprinkles({ marginTop: "4" })}
         id={`sid-input-${handleType}`}
         name={handleType}
+        type="email"
         label={text["initial.handle.email"]}
         placeholder={
           text["initial.handle.phone.email"] ||


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1847)

When entering handle, the inputs have the following types:
- Phone number: `tel`
- Username: `text`
- Email: `text`

This PR changes email to type `email`, and explicitly sets phone number to type `tel` (though, this is the default already).

The intent is better semantics, and to allow better integration with browsers, and other tools depending on the field being correctly typed.