### PR TITLE
[SID-1890] React SDK: Use the core SDK error handling beta

### DIFF
--- a/.changeset/short-yaks-remain.md
+++ b/.changeset/short-yaks-remain.md
@@ -1,0 +1,6 @@
+---
+"@slashid/react": patch
+"@slashid/remix": patch
+---
+
+Update the internal dependency to the @slashid/@slashid SDK

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.26.2",
+    "@slashid/slashid": "3.27.0-errors.3",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/react",
-  "version": "1.27.0",
+  "version": "1.27.1-errors-beta.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/react",
-  "version": "1.27.1-errors-beta.1",
+  "version": "1.27.1-errors-beta.2",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.27.0-errors.6",
+    "@slashid/slashid": "3.27.0",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -100,7 +100,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.26.3",
+    "@slashid/slashid": ">= 3.27.0",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/react",
-  "version": "1.27.1-errors-beta.0",
+  "version": "1.27.1-errors-beta.1",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.27.0-errors.3",
+    "@slashid/slashid": "3.27.0-errors.6",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/react",
-  "version": "1.27.1-errors-beta.2",
+  "version": "1.27.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/form/error/error.test.tsx
+++ b/packages/react/src/components/form/error/error.test.tsx
@@ -1,3 +1,4 @@
+import { Errors, User } from "@slashid/slashid";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -12,7 +13,6 @@ import Deferred, {
   inputUsername,
 } from "../../test-utils";
 import { ConfigurationProvider } from "../../../main";
-import { Errors, User } from "@slashid/slashid";
 import { TEXT } from "../../text/constants";
 
 describe("#Form -> Error state", () => {
@@ -167,7 +167,7 @@ describe("#Form -> Error state -> Special error cases", () => {
   test("should render the noPasswordSet error state", async () => {
     const logInMock = vi.fn(() =>
       Promise.reject(
-        new Errors.SlashIDError({
+        Errors.createSlashIDError({
           name: Errors.ERROR_NAMES.noPasswordSet,
           message: "no password set",
         })
@@ -200,7 +200,7 @@ describe("#Form -> Error state -> Special error cases", () => {
   test("should go back to the initial state as the primary action in noPasswordSet state", async () => {
     const logInMock = vi.fn(() =>
       Promise.reject(
-        new Errors.SlashIDError({
+        Errors.createSlashIDError({
           name: Errors.ERROR_NAMES.noPasswordSet,
           message: "no password set",
         })

--- a/packages/react/src/components/form/error/index.tsx
+++ b/packages/react/src/components/form/error/index.tsx
@@ -33,7 +33,7 @@ type ErrorType =
   | "unknown";
 
 async function getErrorType(error: Error): Promise<ErrorType> {
-  if (await Errors.isTimeoutError(error)) {
+  if (Errors.isTimeoutError(error)) {
     return "timeout";
   }
 

--- a/packages/react/src/components/form/error/index.tsx
+++ b/packages/react/src/components/form/error/index.tsx
@@ -14,10 +14,6 @@ import { Text } from "../../text";
 import { TextConfigKey } from "../../text/constants";
 import { ErrorState } from "../flow";
 import { useInternalFormContext } from "../internal-context";
-import {
-  isNoPasswordSetError,
-  isNonReachableHandleTypeError,
-} from "../../../domain/errors";
 
 import * as styles from "./error.css";
 import { Retry, RetryPolicy } from "../../../domain/types";
@@ -41,7 +37,7 @@ async function getErrorType(error: Error): Promise<ErrorType> {
     return "timeout";
   }
 
-  if (Errors.isResponseError(error)) {
+  if (Errors.isAPIResponseError(error)) {
     return "response";
   }
 
@@ -49,11 +45,11 @@ async function getErrorType(error: Error): Promise<ErrorType> {
     return "rateLimit";
   }
 
-  if (isNonReachableHandleTypeError(error)) {
+  if (Errors.isNonReachableHandleTypeError(error)) {
     return "recoverNonReachableHandleType";
   }
 
-  if (isNoPasswordSetError(error)) {
+  if (Errors.isNoPasswordSetError(error)) {
     return "noPasswordSet";
   }
 

--- a/packages/react/src/components/form/flow.ts
+++ b/packages/react/src/components/form/flow.ts
@@ -9,11 +9,7 @@ import {
   Recover,
   RetryPolicy,
 } from "../../domain/types";
-import {
-  ERROR_NAMES,
-  ensureError,
-  isFlowCancelledError,
-} from "../../domain/errors";
+import { ensureError } from "../../domain/errors";
 import { isFactorRecoverable } from "../../domain/handles";
 import { StoreRecoveryCodesState } from "./store-recovery-codes";
 
@@ -147,7 +143,7 @@ const createAuthenticatingState = (
         send({ type: "sid_login.success", user });
       })
       .catch((error) => {
-        if (isFlowCancelledError(error)) {
+        if (Errors.isFlowCancelledError(error)) {
           return;
         }
         send({ type: "sid_login.error", error });
@@ -161,8 +157,8 @@ const createAuthenticatingState = (
     ) {
       send({
         type: "sid_login.error",
-        error: new Errors.SlashIDError({
-          name: ERROR_NAMES.recoverNonReachableHandleType,
+        error: Errors.createSlashIDError({
+          name: Errors.ERROR_NAMES.recoverNonReachableHandleType,
           message: "Recovery requires a reachable handle type.",
           context,
         }),

--- a/packages/react/src/domain/errors.ts
+++ b/packages/react/src/domain/errors.ts
@@ -1,5 +1,3 @@
-import { Errors } from "@slashid/slashid";
-
 /**
  * Ensure that a valid Error instance is returned, since in JS you can throw anything.
  */
@@ -17,48 +15,4 @@ export function ensureError(value: unknown): Error {
     `This value was thrown as is, not through an Error: ${stringified}`
   );
   return error;
-}
-
-export const ERROR_NAMES = {
-  recoverNonReachableHandleType: "recoverNonReachableHandleType",
-} as const;
-
-type NonReachableHandleTypeError = Error &
-  typeof Errors.SlashIDError & {
-    name: typeof ERROR_NAMES.recoverNonReachableHandleType;
-  };
-
-export function isNonReachableHandleTypeError(
-  error: Error
-): error is NonReachableHandleTypeError {
-  return (
-    Errors.isSlashIDError(error) &&
-    error.name === ERROR_NAMES.recoverNonReachableHandleType
-  );
-}
-
-type NoPasswordSetError = Error &
-  typeof Errors.SlashIDError & {
-    name: typeof Errors.ERROR_NAMES.noPasswordSet;
-  };
-
-export function isNoPasswordSetError(
-  error: Error
-): error is NoPasswordSetError {
-  return (
-    Errors.isSlashIDError(error) &&
-    error.name === Errors.ERROR_NAMES.noPasswordSet
-  );
-}
-
-type FlowCancelledError = Error &
-  typeof Errors.SlashIDError & {
-    // TODO this should probably be exported from the SDK - we should establish a naming convention.
-    name: "FlowCancelledError";
-  };
-
-export function isFlowCancelledError(
-  error: Error
-): error is FlowCancelledError {
-  return Errors.isSlashIDError(error) && error.name == "FlowCancelledError";
 }

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -10,7 +10,7 @@
   "module": "dist/main.js",
   "dependencies": {
     "@slashid/react": "workspace:*",
-    "@slashid/slashid": "3.26.3",
+    "@slashid/slashid": "3.27.0",
     "jose": "^5.2.0",
     "url-join": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.26.3
-        version: 3.26.3
+        specifier: 3.27.0-errors.6
+        version: 3.27.0-errors.6
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.26.2
-        version: 3.26.2
+        specifier: 3.27.0-errors.3
+        version: 3.27.0-errors.3
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -3454,6 +3454,25 @@ packages:
       resolve-from: 5.0.0
       semver: 7.5.4
 
+  /@changesets/apply-release-plan@7.0.4:
+    resolution: {integrity: sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/config': 3.0.2
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.0
+      '@changesets/should-skip-package': 0.1.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.5.4
+    dev: true
+
   /@changesets/assemble-release-plan@5.2.4:
     resolution: {integrity: sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==}
     dependencies:
@@ -3464,10 +3483,28 @@ packages:
       '@manypkg/get-packages': 1.1.3
       semver: 7.5.4
 
+  /@changesets/assemble-release-plan@6.0.3:
+    resolution: {integrity: sha512-bLNh9/Lgl1VwkjWZTq8JmRqH+hj7/Yzfz0jsQ/zJJ+FTmVqmqPj3szeKOri8O/hEM8JmHW019vh2gTO9iq5Cuw==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.1
+      '@changesets/should-skip-package': 0.1.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.5.4
+    dev: true
+
   /@changesets/changelog-git@0.1.14:
     resolution: {integrity: sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==}
     dependencies:
       '@changesets/types': 5.2.1
+
+  /@changesets/changelog-git@0.2.0:
+    resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
+    dependencies:
+      '@changesets/types': 6.0.0
+    dev: true
 
   /@changesets/cli@2.26.2:
     resolution: {integrity: sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==}
@@ -3506,6 +3543,44 @@ packages:
       term-size: 2.2.1
       tty-table: 4.2.3
 
+  /@changesets/cli@2.27.7:
+    resolution: {integrity: sha512-6lr8JltiiXPIjDeYg4iM2MeePP6VN/JkmqBsVA5XRiy01hGS3y629LtSDvKcycj/w/5Eur1rEwby/MjcYS+e2A==}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/apply-release-plan': 7.0.4
+      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/changelog-git': 0.2.0
+      '@changesets/config': 3.0.2
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.1
+      '@changesets/get-release-plan': 4.0.3
+      '@changesets/git': 3.0.0
+      '@changesets/logger': 0.1.0
+      '@changesets/pre': 2.0.0
+      '@changesets/read': 0.6.0
+      '@changesets/should-skip-package': 0.1.0
+      '@changesets/types': 6.0.0
+      '@changesets/write': 0.3.1
+      '@manypkg/get-packages': 1.1.3
+      '@types/semver': 7.5.5
+      ansi-colors: 4.1.3
+      chalk: 2.4.2
+      ci-info: 3.9.0
+      enquirer: 2.4.1
+      external-editor: 3.1.0
+      fs-extra: 7.0.1
+      human-id: 1.0.2
+      mri: 1.2.0
+      outdent: 0.5.0
+      p-limit: 2.3.0
+      preferred-pm: 3.1.2
+      resolve-from: 5.0.0
+      semver: 7.5.4
+      spawndamnit: 2.0.0
+      term-size: 2.2.1
+    dev: true
+
   /@changesets/config@2.3.1:
     resolution: {integrity: sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==}
     dependencies:
@@ -3517,10 +3592,28 @@ packages:
       fs-extra: 7.0.1
       micromatch: 4.0.5
 
+  /@changesets/config@3.0.2:
+    resolution: {integrity: sha512-cdEhS4t8woKCX2M8AotcV2BOWnBp09sqICxKapgLHf9m5KdENpWjyrFNMjkLqGJtUys9U+w93OxWT0czorVDfw==}
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.1
+      '@changesets/logger': 0.1.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.5
+    dev: true
+
   /@changesets/errors@0.1.4:
     resolution: {integrity: sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==}
     dependencies:
       extendable-error: 0.1.7
+
+  /@changesets/errors@0.2.0:
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+    dependencies:
+      extendable-error: 0.1.7
+    dev: true
 
   /@changesets/get-dependents-graph@1.3.6:
     resolution: {integrity: sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==}
@@ -3530,6 +3623,16 @@ packages:
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 7.5.4
+
+  /@changesets/get-dependents-graph@2.1.1:
+    resolution: {integrity: sha512-LRFjjvigBSzfnPU2n/AhFsuWR5DK++1x47aq6qZ8dzYsPtS/I5mNhIGAS68IAxh1xjO9BTtz55FwefhANZ+FCA==}
+    dependencies:
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      chalk: 2.4.2
+      fs-extra: 7.0.1
+      semver: 7.5.4
+    dev: true
 
   /@changesets/get-release-plan@3.0.17:
     resolution: {integrity: sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==}
@@ -3542,8 +3645,24 @@ packages:
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
 
+  /@changesets/get-release-plan@4.0.3:
+    resolution: {integrity: sha512-6PLgvOIwTSdJPTtpdcr3sLtGatT+Jr22+cQwEBJBy6wP0rjB4yJ9lv583J9fVpn1bfQlBkDa8JxbS2g/n9lIyA==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/config': 3.0.2
+      '@changesets/pre': 2.0.0
+      '@changesets/read': 0.6.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+    dev: true
+
   /@changesets/get-version-range-type@0.3.2:
     resolution: {integrity: sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==}
+
+  /@changesets/get-version-range-type@0.4.0:
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+    dev: true
 
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
@@ -3556,16 +3675,41 @@ packages:
       micromatch: 4.0.5
       spawndamnit: 2.0.0
 
+  /@changesets/git@3.0.0:
+    resolution: {integrity: sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.5
+      spawndamnit: 2.0.0
+    dev: true
+
   /@changesets/logger@0.0.5:
     resolution: {integrity: sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==}
     dependencies:
       chalk: 2.4.2
+
+  /@changesets/logger@0.1.0:
+    resolution: {integrity: sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==}
+    dependencies:
+      chalk: 2.4.2
+    dev: true
 
   /@changesets/parse@0.3.16:
     resolution: {integrity: sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==}
     dependencies:
       '@changesets/types': 5.2.1
       js-yaml: 3.14.1
+
+  /@changesets/parse@0.4.0:
+    resolution: {integrity: sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==}
+    dependencies:
+      '@changesets/types': 6.0.0
+      js-yaml: 3.14.1
+    dev: true
 
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
@@ -3575,6 +3719,16 @@ packages:
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
+
+  /@changesets/pre@2.0.0:
+    resolution: {integrity: sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+    dev: true
 
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
@@ -3588,11 +3742,36 @@ packages:
       fs-extra: 7.0.1
       p-filter: 2.1.0
 
+  /@changesets/read@0.6.0:
+    resolution: {integrity: sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/git': 3.0.0
+      '@changesets/logger': 0.1.0
+      '@changesets/parse': 0.4.0
+      '@changesets/types': 6.0.0
+      chalk: 2.4.2
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+    dev: true
+
+  /@changesets/should-skip-package@0.1.0:
+    resolution: {integrity: sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+    dev: true
+
   /@changesets/types@4.1.0:
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
 
   /@changesets/types@5.2.1:
     resolution: {integrity: sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==}
+
+  /@changesets/types@6.0.0:
+    resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
+    dev: true
 
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
@@ -3602,6 +3781,16 @@ packages:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
+
+  /@changesets/write@0.3.1:
+    resolution: {integrity: sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@changesets/types': 6.0.0
+      fs-extra: 7.0.1
+      human-id: 1.0.2
+      prettier: 2.8.8
+    dev: true
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -8181,6 +8370,23 @@ packages:
       ua-parser-js: 1.0.37
       url: 0.11.3
       uuid: 8.3.2
+    dev: false
+
+  /@slashid/slashid@3.27.0-errors.3:
+    resolution: {integrity: sha512-Q6PxvG4OLLO8XAb2PiZXW2K8YhygpsPd8wEAam7cVM4LlTIsCLatO7TKer1eZ74rbcyN8v0NS3wtCcqagvbMCQ==}
+    dependencies:
+      '@changesets/cli': 2.27.7
+      '@types/uuid': 8.3.4
+      compare-versions: 6.1.0
+      docdash: 1.2.0
+      jwt-decode: 3.1.2
+      qrcode: 1.5.3
+      querystring-es3: 0.2.1
+      regenerator-runtime: 0.13.11
+      ua-parser-js: 1.0.37
+      url: 0.11.3
+      uuid: 8.3.2
+    dev: true
 
   /@storybook/addon-actions@7.6.19:
     resolution: {integrity: sha512-ATLrA5QKFJt7tIAScRHz5T3eBQ+RG3jaZk08L7gChvyQZhei8knWwePElZ7GaWbCr9BgznQp1lQUUXq/UUblAQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,8 +613,8 @@ importers:
         specifier: workspace:*
         version: link:../react
       '@slashid/slashid':
-        specifier: 3.26.3
-        version: 3.26.3
+        specifier: 3.27.0
+        version: 3.27.0
       jose:
         specifier: ^5.2.0
         version: 5.2.0
@@ -8338,22 +8338,6 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.26.3:
-    resolution: {integrity: sha512-3kuuikLubZJ21PXGImzCVU+e3WjquHm6bGMVquRvzuSEipESe4Kl57WEhjOQdAUtb+kyd12QcCMO7m4iGvzEOA==}
-    dependencies:
-      '@changesets/cli': 2.27.7
-      '@types/uuid': 8.3.4
-      compare-versions: 6.1.0
-      docdash: 1.2.0
-      jwt-decode: 3.1.2
-      qrcode: 1.5.3
-      querystring-es3: 0.2.1
-      regenerator-runtime: 0.13.11
-      ua-parser-js: 1.0.37
-      url: 0.11.3
-      uuid: 8.3.2
-    dev: false
-
   /@slashid/slashid@3.27.0:
     resolution: {integrity: sha512-uNHItaHp4Hd2qbP9gjMoUZKDOhQpK+mrVwQ4kU4dOxGazcwszv/Uc0wVaDiNoRCCz7vsMeBeqQjmdvkcgQnibQ==}
     dependencies:
@@ -8368,7 +8352,6 @@ packages:
       ua-parser-js: 1.0.37
       url: 0.11.3
       uuid: 8.3.2
-    dev: true
 
   /@storybook/addon-actions@7.6.19:
     resolution: {integrity: sha512-ATLrA5QKFJt7tIAScRHz5T3eBQ+RG3jaZk08L7gChvyQZhei8knWwePElZ7GaWbCr9BgznQp1lQUUXq/UUblAQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.27.0-errors.3
-        version: 3.27.0-errors.3
+        specifier: 3.27.0-errors.6
+        version: 3.27.0-errors.6
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8372,8 +8372,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.27.0-errors.3:
-    resolution: {integrity: sha512-Q6PxvG4OLLO8XAb2PiZXW2K8YhygpsPd8wEAam7cVM4LlTIsCLatO7TKer1eZ74rbcyN8v0NS3wtCcqagvbMCQ==}
+  /@slashid/slashid@3.27.0-errors.6:
+    resolution: {integrity: sha512-AmJVATTCflvnImwcnv5ZRp1ukLYAmy3fejTqj7ptzxPutYZkUmJl8AmbrDTK3xnt28zm1hNZ7tjpLY/eKVTNDQ==}
     dependencies:
       '@changesets/cli': 2.27.7
       '@types/uuid': 8.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.27.0-errors.6
-        version: 3.27.0-errors.6
+        specifier: 3.27.0
+        version: 3.27.0
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8354,8 +8354,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.27.0-errors.6:
-    resolution: {integrity: sha512-AmJVATTCflvnImwcnv5ZRp1ukLYAmy3fejTqj7ptzxPutYZkUmJl8AmbrDTK3xnt28zm1hNZ7tjpLY/eKVTNDQ==}
+  /@slashid/slashid@3.27.0:
+    resolution: {integrity: sha512-uNHItaHp4Hd2qbP9gjMoUZKDOhQpK+mrVwQ4kU4dOxGazcwszv/Uc0wVaDiNoRCCz7vsMeBeqQjmdvkcgQnibQ==}
     dependencies:
       '@changesets/cli': 2.27.7
       '@types/uuid': 8.3.4


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1890)

Use the new type guards and the `SlashIDError` type from the core SDK.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
