### PR TITLE
[SID-1935] Pre-select last used auth method

### DIFF
--- a/.changeset/hot-rules-mix.md
+++ b/.changeset/hot-rules-mix.md
@@ -2,4 +2,4 @@
 "@slashid/react": minor
 ---
 
-Add possibility to store last used authentication factor and pre-select iton next login
+Add possibility to store last used authentication factor and pre-select it on next login

--- a/.changeset/hot-rules-mix.md
+++ b/.changeset/hot-rules-mix.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add possibility to store last used authentication factor and pre-select iton next login

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -421,7 +421,7 @@ describe("<Form /> configuration", () => {
       token: testUser.token,
     });
     expect(setItemSpy).toHaveBeenCalledWith(
-      STORAGE_LAST_FACTOR_KEY,
+      STORAGE_LAST_FACTOR_KEY("test-oid"),
       JSON.stringify({ method: "email_link" })
     );
   });

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -12,6 +12,7 @@ import {
   TestTextProvider,
 } from "../../context/test-providers";
 import { ConfigurationProvider } from "../../context/config-context";
+import { STORAGE_LAST_FACTOR_KEY } from "../../hooks/use-last-factor";
 
 describe("#Form", () => {
   test("should render in the initial state", () => {
@@ -386,6 +387,42 @@ describe("<Form /> configuration", () => {
     expect(setItemSpy).toHaveBeenCalledWith(
       STORAGE_LAST_HANDLE_KEY,
       JSON.stringify(TEST_HANDLE)
+    );
+  });
+
+  test("should store last factor on successful login", async () => {
+    const TEST_HANDLE: PersonHandle = {
+      type: "email_address",
+      value: "test@email.com",
+    };
+    const sid = new MockSlashID({ oid: "test-oid" });
+    const user = userEvent.setup();
+    const testUser = createTestUser();
+    const logInMock = vi.fn(async () => testUser);
+
+    render(
+      <TestSlashIDProvider sdkState="ready" logIn={logInMock} sid={sid}>
+        <ConfigurationProvider storeLastFactor={true}>
+          <Form />
+        </ConfigurationProvider>
+      </TestSlashIDProvider>
+    );
+
+    inputEmail(TEST_HANDLE.value);
+
+    user.click(screen.getByTestId("sid-form-initial-submit-button"));
+
+    await expect(
+      screen.findByTestId("sid-form-success-state")
+    ).resolves.toBeInTheDocument();
+
+    sid.mockPublish("idFlowSucceeded", {
+      authenticationFactor: { method: "email_link" },
+      token: testUser.token,
+    });
+    expect(setItemSpy).toHaveBeenCalledWith(
+      STORAGE_LAST_FACTOR_KEY,
+      JSON.stringify({ method: "email_link" })
     );
   });
 

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -21,6 +21,7 @@ import { Factor } from "@slashid/slashid";
 import { PayloadOptions } from "./types";
 import { InternalFormContext } from "./internal-context";
 import { StoreRecoveryCodes } from "./store-recovery-codes";
+import { useLastFactor } from "../../hooks/use-last-factor";
 
 export type Props = ConfigurationOverridesProps & {
   className?: string;
@@ -49,6 +50,7 @@ export const Form = ({
   const flowState = useFlowState({ onSuccess, onError });
   const { showBanner } = useConfiguration();
   const { lastHandle } = useLastHandle();
+  const { lastFactor } = useLastFactor();
   const submitPayloadRef = React.useRef<PayloadOptions>({
     handleType: undefined,
     handleValue: undefined,
@@ -95,6 +97,7 @@ export const Form = ({
       value={{
         flowState,
         lastHandle,
+        lastFactor,
         handleSubmit,
         submitPayloadRef,
         selectedFactor,

--- a/packages/react/src/components/form/initial/controls.tsx
+++ b/packages/react/src/components/form/initial/controls.tsx
@@ -339,7 +339,8 @@ const HandleInput: React.FC<PropsInternal> = ({
   factors,
   defaultValue,
 }) => {
-  const { setSelectedFactor, submitPayloadRef } = useInternalFormContext();
+  const { setSelectedFactor, submitPayloadRef, lastFactor } =
+    useInternalFormContext();
   const filteredFactors = useMemo(
     () => filterFactors(factors, handleType).filter((f) => !isFactorOidc(f)),
     [factors, handleType]
@@ -353,9 +354,21 @@ const HandleInput: React.FC<PropsInternal> = ({
     findFlag(parsedPhoneNumber?.countryCode ?? defaultCountryCode)!
   );
 
+  const defaultFactor = useMemo(() => {
+    if (
+      lastFactor &&
+      isFactorNonOidc(lastFactor) &&
+      filteredFactors.find(({ method }) => lastFactor.method === method)
+    ) {
+      return lastFactor;
+    }
+
+    return filteredFactors[0];
+  }, [filteredFactors, lastFactor]);
+
   useEffect(() => {
-    setSelectedFactor(filteredFactors[0]);
-  }, [filteredFactors, setSelectedFactor]);
+    setSelectedFactor(defaultFactor);
+  }, [defaultFactor, setSelectedFactor]);
 
   useEffect(() => {
     return resetForm;
@@ -457,7 +470,7 @@ const HandleInput: React.FC<PropsInternal> = ({
     <>
       {shouldRenderFactorDropdown && (
         <Dropdown
-          defaultValue={filteredFactors[0].method}
+          defaultValue={defaultFactor.method}
           className={sprinkles({ marginBottom: "3", marginTop: "6" })}
           label={text["initial.authenticationMethod"]}
           items={filteredFactors.map((f) => ({

--- a/packages/react/src/components/form/internal-context.ts
+++ b/packages/react/src/components/form/internal-context.ts
@@ -7,6 +7,7 @@ import { PayloadOptions } from "./types";
 export type InternalFormContextType = {
   flowState: ReturnType<typeof useFlowState> | null;
   lastHandle?: Handle;
+  lastFactor?: Factor;
   submitPayloadRef: React.MutableRefObject<PayloadOptions>;
   handleSubmit: (factor: Factor, handle?: Handle) => void;
   selectedFactor?: Factor;
@@ -17,6 +18,7 @@ export const InternalFormContext = React.createContext<InternalFormContextType>(
   {
     flowState: null,
     lastHandle: undefined,
+    lastFactor: undefined,
     submitPayloadRef: { current: {} },
     handleSubmit: () => null,
     selectedFactor: undefined,

--- a/packages/react/src/context/config-context.tsx
+++ b/packages/react/src/context/config-context.tsx
@@ -11,6 +11,7 @@ export interface IConfigurationContext {
   factors: FactorConfiguration[];
   logo: Logo;
   storeLastHandle: boolean;
+  storeLastFactor: boolean;
   showBanner: boolean;
   defaultCountryCode: string;
   /** If defined the form in the error state will render a CTA with this link */
@@ -22,6 +23,7 @@ export const initialContextValue: IConfigurationContext = {
   factors: [{ method: "webauthn" }, { method: "email_link" }],
   logo: <SlashID />,
   storeLastHandle: false,
+  storeLastFactor: false,
   showBanner: true,
   defaultCountryCode: "US",
   supportURL: undefined,
@@ -36,6 +38,7 @@ type Props = {
   factors?: FactorConfiguration[];
   logo?: Logo;
   storeLastHandle?: boolean;
+  storeLastFactor?: boolean;
   showBanner?: boolean;
   defaultCountryCode?: string;
   supportURL?: string;

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -43,16 +43,6 @@ export const isHandle = (obj: unknown): obj is Handle => {
   return typeof value === "string";
 };
 
-export const isFactor = (obj: unknown): obj is Factor => {
-  if (!obj) return false;
-  if (Array.isArray(obj)) return false;
-  if (typeof obj !== "object") return false;
-
-  const { method } = obj as Factor;
-  if (!FACTOR_METHODS.includes(method)) return false;
-  return typeof method === "string";
-};
-
 export interface LoginConfiguration {
   handle?: Handle;
   factor: Factor;

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -6,7 +6,6 @@ import {
   User,
 } from "@slashid/slashid";
 import { ReactNode } from "react";
-import { FactorMethod } from "@slashid/slashid";
 
 export const HANDLE_TYPES = [
   "email_address",
@@ -14,18 +13,6 @@ export const HANDLE_TYPES = [
   "username",
 ] as const;
 export type HandleType = (typeof HANDLE_TYPES)[number];
-
-const FACTOR_METHODS: FactorMethod[] = [
-  "email_link",
-  "oidc",
-  "otp_via_email",
-  "otp_via_sms",
-  "password",
-  "webauthn",
-  "totp",
-  "saml",
-  "sms_link",
-];
 
 export interface Handle {
   type: HandleType;

--- a/packages/react/src/domain/types.ts
+++ b/packages/react/src/domain/types.ts
@@ -6,6 +6,7 @@ import {
   User,
 } from "@slashid/slashid";
 import { ReactNode } from "react";
+import { FactorMethod } from "@slashid/slashid";
 
 export const HANDLE_TYPES = [
   "email_address",
@@ -13,6 +14,18 @@ export const HANDLE_TYPES = [
   "username",
 ] as const;
 export type HandleType = (typeof HANDLE_TYPES)[number];
+
+const FACTOR_METHODS: FactorMethod[] = [
+  "email_link",
+  "oidc",
+  "otp_via_email",
+  "otp_via_sms",
+  "password",
+  "webauthn",
+  "totp",
+  "saml",
+  "sms_link",
+];
 
 export interface Handle {
   type: HandleType;
@@ -28,6 +41,16 @@ export const isHandle = (obj: unknown): obj is Handle => {
   if (!HANDLE_TYPES.includes(type)) return false;
 
   return typeof value === "string";
+};
+
+export const isFactor = (obj: unknown): obj is Factor => {
+  if (!obj) return false;
+  if (Array.isArray(obj)) return false;
+  if (typeof obj !== "object") return false;
+
+  const { method } = obj as Factor;
+  if (!FACTOR_METHODS.includes(method)) return false;
+  return typeof method === "string";
 };
 
 export interface LoginConfiguration {

--- a/packages/react/src/hooks/use-last-factor.ts
+++ b/packages/react/src/hooks/use-last-factor.ts
@@ -5,7 +5,8 @@ import { useConfiguration } from "./use-configuration";
 import { useSlashID } from "./use-slash-id";
 import { Factor } from "@slashid/slashid";
 
-export const STORAGE_LAST_FACTOR_KEY = "@slashid/LAST_FACTOR";
+export const STORAGE_LAST_FACTOR_KEY = (oid: string) =>
+  `@slashid/LAST_FACTOR/${oid}`;
 
 type UseLastFactor = () => {
   lastFactor: Factor | undefined;
@@ -25,7 +26,9 @@ export const useLastFactor: UseLastFactor = () => {
     }
 
     try {
-      const storedFactor = window.localStorage.getItem(STORAGE_LAST_FACTOR_KEY);
+      const storedFactor = window.localStorage.getItem(
+        STORAGE_LAST_FACTOR_KEY(sid?.oid ?? "")
+      );
       if (!storeLastFactor || !storedFactor) {
         return undefined;
       }
@@ -34,26 +37,29 @@ export const useLastFactor: UseLastFactor = () => {
     } catch {
       return undefined;
     }
-  }, [storeLastFactor]);
+  }, [storeLastFactor, sid]);
 
-  const handler = useCallback(({ authenticationFactor }: SuccessEvent) => {
-    if (!isBrowser()) {
-      return;
-    }
+  const handler = useCallback(
+    ({ authenticationFactor }: SuccessEvent) => {
+      if (!isBrowser()) {
+        return;
+      }
 
-    if (!isFactor(authenticationFactor)) {
-      return;
-    }
+      if (!isFactor(authenticationFactor)) {
+        return;
+      }
 
-    try {
-      window.localStorage.setItem(
-        STORAGE_LAST_FACTOR_KEY,
-        JSON.stringify(authenticationFactor)
-      );
-    } catch {
-      // do nothing
-    }
-  }, []);
+      try {
+        window.localStorage.setItem(
+          STORAGE_LAST_FACTOR_KEY(sid?.oid ?? ""),
+          JSON.stringify(authenticationFactor)
+        );
+      } catch {
+        // do nothing
+      }
+    },
+    [sid]
+  );
 
   useEffect(() => {
     if (storeLastFactor && sid) {

--- a/packages/react/src/hooks/use-last-factor.ts
+++ b/packages/react/src/hooks/use-last-factor.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useCallback } from "react";
 import { isBrowser } from "@slashid/react-primitives";
-import { Handle, isFactor } from "../domain/types";
+import { Handle } from "../domain/types";
 import { useConfiguration } from "./use-configuration";
 import { useSlashID } from "./use-slash-id";
 import { Factor } from "@slashid/slashid";
@@ -8,7 +8,7 @@ import { Factor } from "@slashid/slashid";
 export const STORAGE_LAST_FACTOR_KEY = (oid: string) =>
   `@slashid/LAST_FACTOR/${oid}`;
 
-type UseLastFactor = () => {
+type UseLastFactorValue = {
   lastFactor: Factor | undefined;
 };
 
@@ -16,7 +16,7 @@ type SuccessEvent = {
   authenticationFactor: Handle | undefined;
 };
 
-export const useLastFactor: UseLastFactor = () => {
+export const useLastFactor = (): UseLastFactorValue => {
   const { storeLastFactor } = useConfiguration();
   const { sid } = useSlashID();
 
@@ -42,10 +42,6 @@ export const useLastFactor: UseLastFactor = () => {
   const handler = useCallback(
     ({ authenticationFactor }: SuccessEvent) => {
       if (!isBrowser()) {
-        return;
-      }
-
-      if (!isFactor(authenticationFactor)) {
         return;
       }
 

--- a/packages/react/src/hooks/use-last-factor.ts
+++ b/packages/react/src/hooks/use-last-factor.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useCallback } from "react";
+import { isBrowser } from "@slashid/react-primitives";
+import { Handle, isHandle } from "../domain/types";
+import { useConfiguration } from "./use-configuration";
+import { useSlashID } from "./use-slash-id";
+import { Factor } from "@slashid/slashid";
+
+export const STORAGE_LAST_FACTOR_KEY = "@slashid/LAST_FACTOR";
+
+type UseLastFactor = () => {
+  lastFactor: Factor | undefined;
+};
+
+type SuccessEvent = {
+  factor: Handle | undefined;
+};
+
+export const useLastFactor: UseLastFactor = () => {
+  const { storeLastFactor } = useConfiguration();
+  const { sid } = useSlashID();
+
+  const lastFactor = useMemo(() => {
+    if (!isBrowser()) {
+      return undefined;
+    }
+
+    try {
+      const storedFactor = window.localStorage.getItem(STORAGE_LAST_FACTOR_KEY);
+      if (!storeLastFactor || !storedFactor) {
+        return undefined;
+      }
+
+      return JSON.parse(storedFactor);
+    } catch {
+      return undefined;
+    }
+  }, [storeLastFactor]);
+
+  const handler = useCallback(({ factor }: SuccessEvent) => {
+    if (!isBrowser()) {
+      return;
+    }
+
+    if (!isHandle(factor)) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(
+        STORAGE_LAST_FACTOR_KEY,
+        JSON.stringify(factor)
+      );
+    } catch {
+      // do nothing
+    }
+  }, []);
+
+  useEffect(() => {
+    if (storeLastFactor && sid) {
+      // @ts-expect-error
+      sid.subscribe("idFlowSucceeded", handler);
+    }
+
+    return () => {
+      if (storeLastFactor && sid) {
+        // @ts-expect-error
+        sid.unsubscribe("idFlowSucceeded", handler);
+      }
+    };
+  }, [storeLastFactor, sid, handler]);
+
+  return { lastFactor };
+};

--- a/packages/react/src/hooks/use-last-factor.ts
+++ b/packages/react/src/hooks/use-last-factor.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useCallback } from "react";
 import { isBrowser } from "@slashid/react-primitives";
-import { Handle, isHandle } from "../domain/types";
+import { Handle, isFactor } from "../domain/types";
 import { useConfiguration } from "./use-configuration";
 import { useSlashID } from "./use-slash-id";
 import { Factor } from "@slashid/slashid";
@@ -12,7 +12,7 @@ type UseLastFactor = () => {
 };
 
 type SuccessEvent = {
-  factor: Handle | undefined;
+  authenticationFactor: Handle | undefined;
 };
 
 export const useLastFactor: UseLastFactor = () => {
@@ -36,19 +36,19 @@ export const useLastFactor: UseLastFactor = () => {
     }
   }, [storeLastFactor]);
 
-  const handler = useCallback(({ factor }: SuccessEvent) => {
+  const handler = useCallback(({ authenticationFactor }: SuccessEvent) => {
     if (!isBrowser()) {
       return;
     }
 
-    if (!isHandle(factor)) {
+    if (!isFactor(authenticationFactor)) {
       return;
     }
 
     try {
       window.localStorage.setItem(
         STORAGE_LAST_FACTOR_KEY,
-        JSON.stringify(factor)
+        JSON.stringify(authenticationFactor)
       );
     } catch {
       // do nothing


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1935)

We already have a functionality to store last used handle. This PR adds another configuration property to store last used authentication factor and pre-select it in the dropdown (works for non-oidc factors only).

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
