### PR TITLE
[SID-1961] Fix the incorrect submit state after resending an OTP code

### DIFF
--- a/.changeset/nasty-bats-warn.md
+++ b/.changeset/nasty-bats-warn.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Fix the incorrect submit state after resending an OTP code

--- a/packages/react/src/components/form/authenticating/messages.ts
+++ b/packages/react/src/components/form/authenticating/messages.ts
@@ -2,9 +2,8 @@ import { Factor } from "@slashid/slashid";
 import { TextConfigKey } from "../../text/constants";
 import { Handle } from "../../../domain/types";
 
-type AuthenticatingMessageOptions = {
-  isSubmitting: boolean;
-  hasRetried: boolean;
+export type AuthenticatingMessageOptions = {
+  state?: "submitting" | "retrying";
 };
 
 type HandleTextTokens = Partial<
@@ -40,10 +39,7 @@ export function getTextTokensFromHandle(
 export function getAuthenticatingMessage(
   factor: Factor,
   handle: Handle | undefined,
-  { isSubmitting, hasRetried }: AuthenticatingMessageOptions = {
-    isSubmitting: false,
-    hasRetried: false,
-  }
+  { state }: AuthenticatingMessageOptions = {}
 ): {
   title: TextConfigKey;
   message: TextConfigKey;
@@ -69,14 +65,14 @@ export function getAuthenticatingMessage(
         tokens: getTextTokensFromHandle(handle),
       };
     case "otp_via_sms": {
-      if (isSubmitting && hasRetried) {
+      if (state === "retrying") {
         return {
           message: "authenticating.retry.message.smsOtp",
           title: "authenticating.retry.title.smsOtp",
           tokens: getTextTokensFromHandle(handle),
         };
       }
-      if (isSubmitting) {
+      if (state === "submitting") {
         return {
           message: "authenticating.submitting.message.smsOtp",
           title: "authenticating.submitting.title.smsOtp",
@@ -90,14 +86,14 @@ export function getAuthenticatingMessage(
       };
     }
     case "otp_via_email":
-      if (isSubmitting && hasRetried) {
+      if (state === "retrying") {
         return {
           message: "authenticating.retry.message.emailOtp",
           title: "authenticating.retry.title.emailOtp",
           tokens: getTextTokensFromHandle(handle),
         };
       }
-      if (isSubmitting) {
+      if (state === "submitting") {
         return {
           message: "authenticating.submitting.message.emailOtp",
           title: "authenticating.submitting.title.emailOtp",


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1961)

Fix the issue where the retry message was displayed instead of the regular submitting message when you submit the OTP code after resending the code at least once.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
