### PR TITLE
[SID-1998] Render the Resend button in the correct state of the OTP flow

### DIFF
--- a/.changeset/healthy-kiwis-yell.md
+++ b/.changeset/healthy-kiwis-yell.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+The Resend prompt/CTA will appear in the expected state when using OTPs

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -184,7 +184,7 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
       )}
       {formState === "submitting" ? <Loader /> : null}
       {formState === "retrying" ? <FactorIcon factor={factor} /> : null}
-      {formState === "input" && (
+      {["input", "initial"].includes(formState) && (
         // fallback to prevent layout shift
         <Delayed
           delayMs={DELAY_BEFORE_RESEND}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-1998)

Render the `resend` button immediately when entering the Authenticating state in the OTP flow.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
