### PR TITLE
[SID-2019] Process the authn context update event

### DIFF
--- a/.changeset/gold-zebras-stare.md
+++ b/.changeset/gold-zebras-stare.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": minor
+---
+
+Add a buffered event subscription mechanism. Wait for the core SDK to establish the authentication context.

--- a/packages/demo-form/src/components/User/index.tsx
+++ b/packages/demo-form/src/components/User/index.tsx
@@ -11,6 +11,11 @@ function decodeToken(token: string): string {
 
 export const User = () => {
   const { user } = useSlashID();
+
+  if (!user) {
+    return null;
+  }
+
   return (
     <>
       <h3>User token</h3>

--- a/packages/demo-form/src/pages/CompositeFormPage/composite-form-page.tsx
+++ b/packages/demo-form/src/pages/CompositeFormPage/composite-form-page.tsx
@@ -3,8 +3,8 @@ import { Form, Slot, ConfigurationProvider } from "@slashid/react";
 import { PageLayout } from "../../components/PageLayout";
 
 import "@slashid/react/style.css";
-import { Handle } from "@slashid/react/dist/domain/types";
 import { useState } from "react";
+import { Handle } from "@slashid/react/dist/react/src/domain/types";
 
 const factors: Factor[] = [{ method: "email_link" }];
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/react",
-  "version": "1.30.0",
+  "version": "1.30.1-identify-hook-beta.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.27.1",
+    "@slashid/slashid": "3.27.4-org-retarget-beta.4",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -100,7 +100,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.27.1",
+    "@slashid/slashid": ">= 3.27.4-org-retarget-beta.3",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.27.4-org-retarget-beta.4",
+    "@slashid/slashid": "3.27.4-org-retarget-beta.8",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -100,7 +100,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.27.4-org-retarget-beta.3",
+    "@slashid/slashid": ">= 3.27.4-org-retarget-beta.5",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.27.4-org-retarget-beta.9",
+    "@slashid/slashid": "3.28.0",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",
@@ -100,7 +100,7 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@slashid/slashid": ">= 3.27.4-org-retarget-beta.5",
+    "@slashid/slashid": ">= 3.28.0",
     "react": ">=16",
     "react-dom": ">=16"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@slashid/slashid": "3.27.4-org-retarget-beta.8",
+    "@slashid/slashid": "3.27.4-org-retarget-beta.9",
     "@storybook/addon-essentials": "7.6.19",
     "@storybook/addon-interactions": "7.4.0",
     "@storybook/addon-links": "7.4.0",

--- a/packages/react/src/components/form/authenticating/authenticating.test.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.test.tsx
@@ -27,6 +27,7 @@ function createTestAuhenticatingState({
     retry: jest.fn(),
     cancel: jest.fn(),
     recover: jest.fn(),
+    updateContext: jest.fn(),
     setRecoveryCodes: jest.fn(),
   };
 }

--- a/packages/react/src/components/form/authenticating/authenticating.test.tsx
+++ b/packages/react/src/components/form/authenticating/authenticating.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { AuthenticatingImplementation as Authenticating } from "./index";
 import { AuthenticatingState } from "../flow";
-import { TestTextProvider } from "../../../context/test-providers";
+import {
+  TestSlashIDProvider,
+  TestTextProvider,
+} from "../../../context/test-providers";
 import { TEXT } from "../../text/constants";
+import { MockSlashID } from "../../test-utils";
 
 type CreateTestAuthenticatingStateInput = {
   factor: AuthenticatingState["context"]["config"]["factor"];
@@ -33,45 +37,74 @@ function createTestAuhenticatingState({
 }
 
 describe("Authenticating", () => {
-  test("should render the email link authenticating state", () => {
+  test("should render the email link authenticating state", async () => {
     const flowState: AuthenticatingState = createTestAuhenticatingState({
       factor: { method: "email_link" },
       handle: { type: "email_address", value: "test@mail.com" },
     });
+    const logInMock = vi.fn();
+    const mockSlashID = new MockSlashID({
+      oid: "oid",
+      analyticsEnabled: false,
+    });
 
     render(
-      <TestTextProvider text={TEXT}>
-        <Authenticating flowState={flowState} />
-      </TestTextProvider>
+      <TestSlashIDProvider sid={mockSlashID} sdkState="ready" logIn={logInMock}>
+        <TestTextProvider text={TEXT}>
+          <Authenticating flowState={flowState} />
+        </TestTextProvider>
+      </TestSlashIDProvider>
     );
 
-    expect(
-      screen.getByTestId("sid-form-authenticating-state")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/test@mail.com/)).toBeInTheDocument();
+    mockSlashID.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "oid",
+      factor: { method: "email_link" },
+    });
+
+    const authnState = await screen.findByTestId(
+      "sid-form-authenticating-state"
+    );
+    expect(authnState).toBeInTheDocument();
+
+    const emailDisplay = await screen.findByText(/test@mail.com/);
+    expect(emailDisplay).toBeInTheDocument();
   });
 
-  test("should not render the subtitle if `authenticating.subtitle` is not set", () => {
+  test("should not render the subtitle if `authenticating.subtitle` is not set", async () => {
     const flowState: AuthenticatingState = createTestAuhenticatingState({
       factor: { method: "email_link" },
       handle: { type: "email_address", value: "test@mail.test" },
     });
+    const logInMock = vi.fn();
+    const mockSlashID = new MockSlashID({
+      oid: "oid",
+      analyticsEnabled: false,
+    });
 
     render(
-      <TestTextProvider text={TEXT}>
-        <Authenticating flowState={flowState} />
-      </TestTextProvider>
+      <TestSlashIDProvider sid={mockSlashID} sdkState="ready" logIn={logInMock}>
+        <TestTextProvider text={TEXT}>
+          <Authenticating flowState={flowState} />
+        </TestTextProvider>
+      </TestSlashIDProvider>
     );
 
-    expect(
-      screen.getByTestId("sid-form-authenticating-state")
-    ).toBeInTheDocument();
+    mockSlashID.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "oid",
+      factor: { method: "email_link" },
+    });
+
+    const authnState = await screen.findByTestId(
+      "sid-form-authenticating-state"
+    );
+    expect(authnState).toBeInTheDocument();
+
     expect(
       screen.queryByTestId("sid-text-authenticating-subtitle")
     ).toBeFalsy();
   });
 
-  test("should render the subtitle if `authenticating.subtitle` is set", () => {
+  test("should render the subtitle if `authenticating.subtitle` is set", async () => {
     const flowState: AuthenticatingState = createTestAuhenticatingState({
       factor: { method: "email_link" },
       handle: { type: "email_address", value: "test@mail.test" },
@@ -80,16 +113,31 @@ describe("Authenticating", () => {
       ...TEXT,
       "authenticating.subtitle": "Authenticating subtitle",
     };
+    const logInMock = vi.fn();
+    const mockSlashID = new MockSlashID({
+      oid: "oid",
+      analyticsEnabled: false,
+    });
 
     render(
-      <TestTextProvider text={textWithAuthenticatingSubtitle}>
-        <Authenticating flowState={flowState} />
-      </TestTextProvider>
+      <TestSlashIDProvider sid={mockSlashID} sdkState="ready" logIn={logInMock}>
+        <TestTextProvider text={textWithAuthenticatingSubtitle}>
+          <Authenticating flowState={flowState} />
+        </TestTextProvider>
+      </TestSlashIDProvider>
     );
 
-    expect(
-      screen.getByTestId("sid-form-authenticating-state")
-    ).toBeInTheDocument();
-    expect(screen.getByText("Authenticating subtitle")).toBeInTheDocument();
+    mockSlashID.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "oid",
+      factor: { method: "email_link" },
+    });
+
+    const authnState = await screen.findByTestId(
+      "sid-form-authenticating-state"
+    );
+    expect(authnState).toBeInTheDocument();
+
+    const subtitle = await screen.findByText("Authenticating subtitle");
+    expect(subtitle).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/form/authenticating/authenticating.types.ts
+++ b/packages/react/src/components/form/authenticating/authenticating.types.ts
@@ -2,5 +2,4 @@ import { AuthenticatingState } from "../flow";
 
 export type Props = {
   flowState: AuthenticatingState;
-  performLogin: () => void;
 };

--- a/packages/react/src/components/form/authenticating/otp.tsx
+++ b/packages/react/src/components/form/authenticating/otp.tsx
@@ -66,9 +66,9 @@ function mapFormStateToMessageState(
  * Presents the user with a form to enter an OTP code.
  * Handles retries in case of submitting an incorrect OTP code.
  */
-export const OTPState = ({ flowState, performLogin }: Props) => {
+export const OTPState = ({ flowState }: Props) => {
   const { text } = useConfiguration();
-  const { sid } = useSlashID();
+  const { sid, subscribe, unsubscribe } = useSlashID();
   const { values, registerField, registerSubmit, setError, clearError } =
     useForm();
   const [formState, setFormState] = useState<FormState>("initial");
@@ -91,18 +91,14 @@ export const OTPState = ({ flowState, performLogin }: Props) => {
       setFormState("input");
     };
 
-    sid?.subscribe("otpCodeSent", onOtpCodeSent);
-    sid?.subscribe("otpIncorrectCodeSubmitted", onOtpIncorrectCodeSubmitted);
-    performLogin();
+    subscribe("otpCodeSent", onOtpCodeSent);
+    subscribe("otpIncorrectCodeSubmitted", onOtpIncorrectCodeSubmitted);
 
     return () => {
-      sid?.unsubscribe("otpCodeSent", onOtpCodeSent);
-      sid?.unsubscribe(
-        "otpIncorrectCodeSubmitted",
-        onOtpIncorrectCodeSubmitted
-      );
+      unsubscribe("otpCodeSent", onOtpCodeSent);
+      unsubscribe("otpIncorrectCodeSubmitted", onOtpIncorrectCodeSubmitted);
     };
-  }, [formState, performLogin, setError, sid, text, values]);
+  }, [formState, setError, sid, subscribe, text, unsubscribe, values]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (e) => {

--- a/packages/react/src/components/form/authenticating/password.tsx
+++ b/packages/react/src/components/form/authenticating/password.tsx
@@ -137,8 +137,8 @@ function getTextKeys(
  * Renders a form that enables authentication via a password.
  * Handles retries in case of submitting an invalid/incorrect password.
  */
-export const PasswordState = ({ flowState, performLogin }: Props) => {
-  const { sid } = useSlashID();
+export const PasswordState = ({ flowState }: Props) => {
+  const { sid, subscribe, unsubscribe } = useSlashID();
   const { text } = useConfiguration();
   const {
     values,
@@ -243,20 +243,18 @@ export const PasswordState = ({ flowState, performLogin }: Props) => {
         ),
       });
 
-    sid?.subscribe("passwordSetReady", onSetPassword);
-    sid?.subscribe("passwordVerifyReady", onVerifyPassword);
-    sid?.subscribe("incorrectPasswordSubmitted", onIncorrectPassword);
-    sid?.subscribe("invalidPasswordSubmitted", onInvalidPassword);
-
-    performLogin();
+    subscribe("passwordSetReady", onSetPassword);
+    subscribe("passwordVerifyReady", onVerifyPassword);
+    subscribe("incorrectPasswordSubmitted", onIncorrectPassword);
+    subscribe("invalidPasswordSubmitted", onInvalidPassword);
 
     return () => {
-      sid?.unsubscribe("passwordSetReady", onSetPassword);
-      sid?.unsubscribe("passwordVerifyReady", onVerifyPassword);
-      sid?.unsubscribe("incorrectPasswordSubmitted", onIncorrectPassword);
-      sid?.unsubscribe("invalidPasswordSubmitted", onInvalidPassword);
+      unsubscribe("passwordSetReady", onSetPassword);
+      unsubscribe("passwordVerifyReady", onVerifyPassword);
+      unsubscribe("incorrectPasswordSubmitted", onIncorrectPassword);
+      unsubscribe("invalidPasswordSubmitted", onInvalidPassword);
     };
-  }, [formState, performLogin, setError, sid, text, values]);
+  }, [formState, setError, sid, subscribe, text, unsubscribe, values]);
 
   return (
     <>

--- a/packages/react/src/components/form/authenticating/totp.tsx
+++ b/packages/react/src/components/form/authenticating/totp.tsx
@@ -63,8 +63,8 @@ function getTextKeys(formState: FormState) {
   return TEXT_KEYS[formState];
 }
 
-export function TOTPState({ flowState, performLogin }: Props) {
-  const { sid } = useSlashID();
+export function TOTPState({ flowState }: Props) {
+  const { sid, subscribe, unsubscribe } = useSlashID();
   const { text } = useConfiguration();
   const { values, registerField, registerSubmit, setError, clearError } =
     useForm();
@@ -101,22 +101,17 @@ export function TOTPState({ flowState, performLogin }: Props) {
       setFormState("input");
     };
 
-    sid?.subscribe(
-      "otpIncorrectCodeSubmitted",
-      otpIncorrectCodeSubmittedHandler
-    );
-    sid?.subscribe("totpCodeRequested", totpCodeRequestedHandler);
-    sid?.subscribe("totpKeyGenerated", totpKeyGeneratedHandler);
-
-    performLogin();
+    subscribe("otpIncorrectCodeSubmitted", otpIncorrectCodeSubmittedHandler);
+    subscribe("totpCodeRequested", totpCodeRequestedHandler);
+    subscribe("totpKeyGenerated", totpKeyGeneratedHandler);
 
     return () => {
-      sid?.unsubscribe(
+      unsubscribe(
         "otpIncorrectCodeSubmitted",
         otpIncorrectCodeSubmittedHandler
       );
-      sid?.unsubscribe("totpCodeRequested", totpCodeRequestedHandler);
-      sid?.unsubscribe("totpKeyGenerated", totpKeyGeneratedHandler);
+      unsubscribe("totpCodeRequested", totpCodeRequestedHandler);
+      unsubscribe("totpKeyGenerated", totpKeyGeneratedHandler);
     };
   }, [
     formState,
@@ -124,9 +119,10 @@ export function TOTPState({ flowState, performLogin }: Props) {
     sid,
     text,
     values,
-    performLogin,
     flowState,
     isRegisterFlow,
+    subscribe,
+    unsubscribe,
   ]);
 
   const handleChange = useCallback(

--- a/packages/react/src/components/form/error/error.test.tsx
+++ b/packages/react/src/components/form/error/error.test.tsx
@@ -332,7 +332,6 @@ describe("#Form -> Error state -> Special error cases", () => {
     inputUsername("non-reachable");
 
     user.click(screen.getByTestId("sid-form-initial-submit-button"));
-    console.log("clicked");
 
     // go to authenticating state
     await expect(

--- a/packages/react/src/components/form/error/error.test.tsx
+++ b/packages/react/src/components/form/error/error.test.tsx
@@ -243,7 +243,13 @@ describe("#Form -> Error state -> Special error cases", () => {
       analyticsEnabled: false,
     });
     const logInPromise = new Deferred<User>();
-    const logInMock = vi.fn(() => logInPromise);
+    const logInMock = vi.fn(() => {
+      mockSlashID.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+        targetOrgId: "oid",
+        factor: { method: "password" },
+      });
+      return logInPromise;
+    });
     const user = userEvent.setup();
     const testTitle = "Recover non reachable handle";
 
@@ -297,7 +303,13 @@ describe("#Form -> Error state -> Special error cases", () => {
       analyticsEnabled: false,
     });
     const logInPromise = new Deferred<User>();
-    const logInMock = vi.fn(() => logInPromise);
+    const logInMock = vi.fn(() => {
+      mockSlashID.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+        targetOrgId: "oid",
+        factor: { method: "password" },
+      });
+      return logInPromise;
+    });
     const user = userEvent.setup();
     const testTitle = "Recover non reachable handle";
 
@@ -320,6 +332,7 @@ describe("#Form -> Error state -> Special error cases", () => {
     inputUsername("non-reachable");
 
     user.click(screen.getByTestId("sid-form-initial-submit-button"));
+    console.log("clicked");
 
     // go to authenticating state
     await expect(

--- a/packages/react/src/components/form/event-buffer.test.ts
+++ b/packages/react/src/components/form/event-buffer.test.ts
@@ -84,4 +84,32 @@ describe("createEventBuffer", () => {
     });
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it("should only let the first subscriber consume the buffered events", () => {
+    const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
+    const eventBuffer = createEventBuffer({ sdk });
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    const testEvent = {
+      targetOrgId: "test org ID",
+    };
+
+    // Event before first subscription
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
+
+    // Subscribe to the event
+    eventBuffer.subscribe(
+      "authnContextUpdateChallengeReceivedEvent",
+      firstCallback
+    );
+    eventBuffer.subscribe(
+      "authnContextUpdateChallengeReceivedEvent",
+      secondCallback
+    );
+
+    expect(firstCallback).toHaveBeenCalledTimes(1);
+    expect(firstCallback).toHaveBeenCalledWith(testEvent);
+    expect(secondCallback).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/components/form/event-buffer.test.ts
+++ b/packages/react/src/components/form/event-buffer.test.ts
@@ -12,14 +12,11 @@ describe("createEventBuffer", () => {
       targetOrgId: "test org ID",
     };
 
-    // Simulate event emissions
     sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
     sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
 
-    // Subscribe to the event
     eventBuffer.subscribe("authnContextUpdateChallengeReceivedEvent", callback);
 
-    // Verify that the callback is called with the buffered event
     expect(callback).toHaveBeenCalledWith(testEvent);
     expect(callback).toHaveBeenCalledTimes(2);
   });
@@ -58,7 +55,6 @@ describe("createEventBuffer", () => {
       targetOrgId: "orgId3",
     });
 
-    // Verify that the callback is called with the buffered event
     expect(firstCallback).toHaveBeenCalledTimes(3);
     expect(secondCallback).toHaveBeenCalledTimes(1);
     expect(secondCallback).toHaveBeenCalledWith(finalTestEvent);
@@ -83,9 +79,6 @@ describe("createEventBuffer", () => {
       targetOrgId: "2",
     });
 
-    // Subscribe to the event
-
-    // Verify that the callback is called with the buffered event
     expect(callback).toHaveBeenLastCalledWith({
       targetOrgId: "1",
     });

--- a/packages/react/src/components/form/event-buffer.test.ts
+++ b/packages/react/src/components/form/event-buffer.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { createEventBuffer } from "./event-buffer";
+import { MockSlashID } from "../test-utils";
+
+describe("createEventBuffer", () => {
+  it("should call the subscriber with buffered events if they were emitted prior to them subscribing", () => {
+    const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
+    const eventBuffer = createEventBuffer({ sdk });
+    const callback = vi.fn();
+
+    const testEvent = {
+      targetOrgId: "test org ID",
+    };
+
+    // Simulate event emissions
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
+
+    // Subscribe to the event
+    eventBuffer.subscribe("authnContextUpdateChallengeReceivedEvent", callback);
+
+    // Verify that the callback is called with the buffered event
+    expect(callback).toHaveBeenCalledWith(testEvent);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not buffer events if subscribers exist", () => {
+    const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
+    const eventBuffer = createEventBuffer({ sdk });
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    const testEvent = {
+      targetOrgId: "test org ID",
+    };
+
+    const finalTestEvent = { targetOrgId: "orgId3" };
+
+    // Event before first subscription
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
+
+    // Subscribe to the event
+    eventBuffer.subscribe(
+      "authnContextUpdateChallengeReceivedEvent",
+      firstCallback
+    );
+
+    // one subscriber
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", testEvent);
+
+    eventBuffer.subscribe(
+      "authnContextUpdateChallengeReceivedEvent",
+      secondCallback
+    );
+
+    // two subscribers
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "orgId3",
+    });
+
+    // Verify that the callback is called with the buffered event
+    expect(firstCallback).toHaveBeenCalledTimes(3);
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+    expect(secondCallback).toHaveBeenCalledWith(finalTestEvent);
+  });
+
+  it("should not receive events while unsubscribed", () => {
+    const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
+    const eventBuffer = createEventBuffer({ sdk });
+    const callback = vi.fn();
+
+    eventBuffer.subscribe("authnContextUpdateChallengeReceivedEvent", callback);
+
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "1",
+    });
+
+    eventBuffer.unsubscribe(
+      "authnContextUpdateChallengeReceivedEvent",
+      callback
+    );
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "2",
+    });
+
+    // Subscribe to the event
+
+    // Verify that the callback is called with the buffered event
+    expect(callback).toHaveBeenLastCalledWith({
+      targetOrgId: "1",
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/components/form/event-buffer.test.ts
+++ b/packages/react/src/components/form/event-buffer.test.ts
@@ -112,4 +112,27 @@ describe("createEventBuffer", () => {
     expect(firstCallback).toHaveBeenCalledWith(testEvent);
     expect(secondCallback).not.toHaveBeenCalled();
   });
+
+  it("should not receive events after destroy", () => {
+    const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
+    const eventBuffer = createEventBuffer({ sdk });
+    const callback = vi.fn();
+
+    eventBuffer.subscribe("authnContextUpdateChallengeReceivedEvent", callback);
+
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "1",
+    });
+
+    eventBuffer.destroy();
+
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "2",
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenLastCalledWith({
+      targetOrgId: "1",
+    });
+  });
 });

--- a/packages/react/src/components/form/event-buffer.ts
+++ b/packages/react/src/components/form/event-buffer.ts
@@ -94,7 +94,6 @@ export function createEventBuffer({ sdk }: CreateEventBufferArgs): EventBuffer {
   }
 
   function destroy() {
-    console.log({ internalHandlers });
     // unsubscribe
     internalHandlers.forEach((handler, name) => {
       sdk.unsubscribe(name, handler);

--- a/packages/react/src/components/form/event-buffer.ts
+++ b/packages/react/src/components/form/event-buffer.ts
@@ -1,0 +1,117 @@
+import type { SlashID, PublicReadEvents } from "@slashid/slashid";
+import { Utils } from "@slashid/slashid";
+
+export type Event = PublicReadEvents[keyof PublicReadEvents];
+
+type EventNames = keyof PublicReadEvents;
+
+export type EventCallback = (event: Event) => void;
+
+export type CreateEventBufferArgs = {
+  sdk: SlashID;
+};
+
+export type EventBuffer = {
+  subscribe: (eventName: EventNames, handler: EventCallback) => void;
+  unsubscribe: (eventName: EventNames, handler: EventCallback) => void;
+  destroy: () => void;
+};
+
+export function createEventBuffer({ sdk }: CreateEventBufferArgs): EventBuffer {
+  const buffer: Map<EventNames, Event[]> = new Map();
+  const internalHandlers: Map<EventNames, EventCallback> = new Map();
+  const subscribers: Map<EventNames, EventCallback[]> = new Map();
+
+  // listen to all the SDK events on init
+  Utils.PUBLIC_READ_EVENTS.forEach((publicReadEventName: EventNames) => {
+    // create an event handler
+    const handler = (event: Event) => {
+      if (subscribers.has(publicReadEventName)) {
+        // if there is a subscriber for this event type just ignore
+        return;
+      }
+
+      // add event to the corresponding buffer
+      if (!buffer.has(publicReadEventName)) {
+        buffer.set(publicReadEventName, []);
+      }
+
+      const existingEvents = buffer.get(publicReadEventName);
+      if (existingEvents) {
+        existingEvents.push(event);
+      }
+    };
+
+    // subscribe to the given event
+    sdk.subscribe(publicReadEventName, handler);
+
+    // store the handler so we can unsubscribe later
+    internalHandlers.set(publicReadEventName, handler);
+  });
+
+  /**
+   * When you subscribe for an event type with buffered instances, your callback will be called once per each stored event.
+   * Event will be consumed and removed from the buffer.
+   */
+  function subscribe(eventType: EventNames, callback: EventCallback) {
+    sdk.subscribe(eventType, callback);
+
+    // add to our list of subscribers
+    if (!subscribers.has(eventType)) {
+      subscribers.set(eventType, []);
+    }
+
+    const existingSubscribers = subscribers.get(eventType);
+    if (existingSubscribers) {
+      existingSubscribers.push(callback);
+    }
+
+    if (buffer.has(eventType)) {
+      buffer.get(eventType)!.forEach((event) => callback(event));
+      buffer.delete(eventType);
+    }
+  }
+
+  /**
+   * When you unsubscribe we need to remove your callback from the internal list of stored callbacks.
+   * This way we know when to buffer (only when there are no subscribers to the given event).
+   */
+  function unsubscribe(eventType: EventNames, callback: EventCallback) {
+    sdk.unsubscribe(eventType, callback);
+
+    if (!subscribers.has(eventType)) {
+      return;
+    }
+
+    const registeredSubscribers = subscribers.get(eventType);
+
+    if (registeredSubscribers) {
+      const newSubscribers = registeredSubscribers.filter(
+        (sub) => sub !== callback
+      );
+      subscribers.set(eventType, newSubscribers);
+    }
+  }
+
+  function destroy() {
+    // unsubscribe
+    internalHandlers.entries().forEach(([name, handler]) => {
+      sdk.unsubscribe(name, handler);
+    });
+
+    // clear
+    internalHandlers.keys().forEach((name) => {
+      internalHandlers.delete(name);
+    });
+
+    subscribers.keys().forEach((name) => {
+      subscribers.delete(name);
+    });
+  }
+
+  return {
+    subscribe,
+    unsubscribe,
+    destroy,
+  };
+}

--- a/packages/react/src/components/form/event-buffer.ts
+++ b/packages/react/src/components/form/event-buffer.ts
@@ -94,17 +94,20 @@ export function createEventBuffer({ sdk }: CreateEventBufferArgs): EventBuffer {
   }
 
   function destroy() {
+    console.log({ internalHandlers });
     // unsubscribe
-    internalHandlers.entries().forEach(([name, handler]) => {
+    internalHandlers.forEach((handler, name) => {
       sdk.unsubscribe(name, handler);
     });
 
     // clear
-    internalHandlers.keys().forEach((name) => {
+    internalHandlers.forEach((_, name) => {
       internalHandlers.delete(name);
     });
 
-    subscribers.keys().forEach((name) => {
+    subscribers.forEach((callbacks, name) => {
+      // clear all subscriptions from the SDK
+      callbacks.forEach((cb) => sdk.unsubscribe(name, cb));
       subscribers.delete(name);
     });
   }

--- a/packages/react/src/components/form/form.test.tsx
+++ b/packages/react/src/components/form/form.test.tsx
@@ -181,17 +181,24 @@ describe("#Form", () => {
   test("should transition from authenticating to initial state on the back button click", async () => {
     // used to store the resolve callback
     let r: undefined | ((u: User) => void);
-    const logInMock = vi.fn(
-      () =>
-        new Promise<User>((resolve) => {
-          // keep a reference to resolve so we can resolve the promise to prevent memory leaks after the test is done
-          r = resolve;
-        })
-    );
+    const mockSlashID = new MockSlashID({
+      oid: "oid",
+      analyticsEnabled: false,
+    });
+    const logInMock = vi.fn(() => {
+      mockSlashID.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+        targetOrgId: "oid",
+        factor: { method: "password" },
+      });
+      return new Promise<User>((resolve) => {
+        // keep a reference to resolve so we can resolve the promise to prevent memory leaks after the test is done
+        r = resolve;
+      });
+    });
     const user = userEvent.setup();
 
     render(
-      <TestSlashIDProvider sdkState="ready" logIn={logInMock}>
+      <TestSlashIDProvider sid={mockSlashID} sdkState="ready" logIn={logInMock}>
         <TestTextProvider text={TEXT}>
           <Form />
         </TestTextProvider>

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -299,7 +299,7 @@ export const SlashIDProvider = ({
 
         const newUser = await sid
           // @ts-expect-error TODO make the identifier optional
-          .idV2(oid, identifier, factor)
+          .id(oid, identifier, factor)
           .then(async (user) => {
             return applyMiddleware({ user, sid, middleware });
           });

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -82,8 +82,8 @@ export interface SlashIDProviderProps {
  */
 type ExternalStateParams = Pick<SlashIDProviderProps, "oid" | "initialToken">;
 
-type Subscribe = SlashID["subscribe"];
-type Unsubscribe = SlashID["unsubscribe"];
+export type Subscribe = SlashID["subscribe"];
+export type Unsubscribe = SlashID["unsubscribe"];
 
 export interface ISlashIDContext {
   sid: SlashID | undefined;
@@ -381,7 +381,7 @@ export const SlashIDProvider = ({
     [state]
   );
 
-  const unsubscribe = useCallback<Subscribe>(
+  const unsubscribe = useCallback<Unsubscribe>(
     (event, handler) => {
       if (state === "initial") {
         return;

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -26,6 +26,10 @@ import { SDKState } from "../domain/sdk-state";
 import { applyMiddleware } from "../middleware";
 import { isAnonymous } from "../domain/user";
 import { sequence } from "../components/utils";
+import {
+  createEventBuffer,
+  EventBuffer,
+} from "../components/form/event-buffer";
 
 export type StorageOption = "memory" | "localStorage" | "cookie";
 
@@ -78,6 +82,9 @@ export interface SlashIDProviderProps {
  */
 type ExternalStateParams = Pick<SlashIDProviderProps, "oid" | "initialToken">;
 
+type Subscribe = SlashID["subscribe"];
+type Unsubscribe = SlashID["unsubscribe"];
+
 export interface ISlashIDContext {
   sid: SlashID | undefined;
   user: User | undefined;
@@ -85,6 +92,8 @@ export interface ISlashIDContext {
   sdkState: SDKState;
   logOut: () => undefined;
   logIn: LogIn;
+  subscribe: Subscribe;
+  unsubscribe: Unsubscribe;
   mfa: MFA;
   recover: Recover;
   validateToken: (token: string) => Promise<boolean>;
@@ -101,6 +110,8 @@ export const initialContextValue = {
   logIn: () => Promise.reject("NYI"),
   mfa: () => Promise.reject("NYI"),
   recover: () => Promise.reject("NYI"),
+  subscribe: () => undefined,
+  unsubscribe: () => undefined,
   validateToken: async () => false,
   __switchOrganizationInContext: async () => undefined,
   __syncExternalState: async () => undefined,
@@ -146,6 +157,7 @@ export const SlashIDProvider = ({
   );
   const storageRef = useRef<Storage | undefined>(undefined);
   const sidRef = useRef<SlashID | undefined>(undefined);
+  const eventBufferRef = useRef<EventBuffer | undefined>();
 
   /**
    * Restarts the React SDK lifecycle with a new
@@ -287,7 +299,7 @@ export const SlashIDProvider = ({
 
         const newUser = await sid
           // @ts-expect-error TODO make the identifier optional
-          .id(oid, identifier, factor)
+          .idV2(oid, identifier, factor)
           .then(async (user) => {
             return applyMiddleware({ user, sid, middleware });
           });
@@ -344,6 +356,48 @@ export const SlashIDProvider = ({
       if (state !== "ready" || !sidRef.current) return;
 
       return sidRef.current?.recover({ factor, handle });
+    },
+    [state]
+  );
+
+  const subscribe = useCallback<Subscribe>(
+    (event, handler) => {
+      if (state === "initial") {
+        return;
+      }
+
+      const sid = sidRef.current;
+      if (!sid) {
+        return;
+      }
+
+      if (!eventBufferRef.current) {
+        eventBufferRef.current = createEventBuffer({ sdk: sid });
+      }
+
+      // @ts-expect-error no idea why it complains
+      eventBufferRef.current.subscribe(event, handler);
+    },
+    [state]
+  );
+
+  const unsubscribe = useCallback<Subscribe>(
+    (event, handler) => {
+      if (state === "initial") {
+        return;
+      }
+
+      const sid = sidRef.current;
+      if (!sid) {
+        return;
+      }
+
+      if (!eventBufferRef.current) {
+        return;
+      }
+
+      // @ts-expect-error no idea why it complains
+      eventBufferRef.current.unsubscribe(event, handler);
     },
     [state]
   );
@@ -521,6 +575,8 @@ export const SlashIDProvider = ({
         mfa,
         recover,
         validateToken,
+        subscribe,
+        unsubscribe,
         __switchOrganizationInContext,
         __syncExternalState,
       };
@@ -535,6 +591,8 @@ export const SlashIDProvider = ({
       logIn,
       mfa,
       recover,
+      subscribe,
+      unsubscribe,
       validateToken,
       __switchOrganizationInContext,
       __syncExternalState,
@@ -547,6 +605,8 @@ export const SlashIDProvider = ({
     logIn,
     mfa,
     recover,
+    subscribe,
+    unsubscribe,
     validateToken,
     __switchOrganizationInContext,
     __syncExternalState,

--- a/packages/react/src/dev.tsx
+++ b/packages/react/src/dev.tsx
@@ -387,6 +387,7 @@ root.render(
             cancel: () => {},
             recover: () => {},
             logIn: () => {},
+            updateContext: () => {},
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             setRecoveryCodes: (_code: string[]) => {},
           };

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -10,7 +10,7 @@
   "module": "dist/main.js",
   "dependencies": {
     "@slashid/react": "workspace:*",
-    "@slashid/slashid": "3.27.1",
+    "@slashid/slashid": "3.28.0",
     "jose": "^5.2.0",
     "url-join": "^5.0.0"
   },

--- a/packages/remix/src/slashid-provider.tsx
+++ b/packages/remix/src/slashid-provider.tsx
@@ -48,6 +48,8 @@ function SlashIDProviderSSR({
       mfa: () => Promise.reject("Operation not possible in this state"),
       recover: () => Promise.reject("Operation not possible in this state"),
       validateToken: async () => false,
+      subscribe: () => undefined,
+      unsubscribe: () => undefined,
       __switchOrganizationInContext: async () => undefined,
       __syncExternalState() {
         throw new Error("Operation not possible in this state");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.27.1
-        version: 3.27.1
+        specifier: 3.27.4-org-retarget-beta.4
+        version: 3.27.4-org-retarget-beta.4
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8352,6 +8352,23 @@ packages:
       ua-parser-js: 1.0.37
       url: 0.11.3
       uuid: 8.3.2
+    dev: false
+
+  /@slashid/slashid@3.27.4-org-retarget-beta.4:
+    resolution: {integrity: sha512-mdyN2klNnA8XjgeRNkqvaKpR/GQCUTPmtH/W//YRrB4G8PfoukroQ8zETQvdRBY1egpFBMZkDaFwWKCnZ69OKQ==}
+    dependencies:
+      '@changesets/cli': 2.27.7
+      '@types/uuid': 8.3.4
+      compare-versions: 6.1.0
+      docdash: 1.2.0
+      jwt-decode: 3.1.2
+      qrcode: 1.5.3
+      querystring-es3: 0.2.1
+      regenerator-runtime: 0.13.11
+      ua-parser-js: 1.0.37
+      url: 0.11.3
+      uuid: 8.3.2
+    dev: true
 
   /@storybook/addon-actions@7.6.19:
     resolution: {integrity: sha512-ATLrA5QKFJt7tIAScRHz5T3eBQ+RG3jaZk08L7gChvyQZhei8knWwePElZ7GaWbCr9BgznQp1lQUUXq/UUblAQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.27.4-org-retarget-beta.8
-        version: 3.27.4-org-retarget-beta.8
+        specifier: 3.27.4-org-retarget-beta.9
+        version: 3.27.4-org-retarget-beta.9
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8354,8 +8354,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.27.4-org-retarget-beta.8:
-    resolution: {integrity: sha512-IPW57L3cA49lJkByHyzdPUsa1pKz6tPJQQ3fjwzySqLBla90DXzg38jJ6uXyS3pEo+hVrIE7HUZ8lMXTYB0T5A==}
+  /@slashid/slashid@3.27.4-org-retarget-beta.9:
+    resolution: {integrity: sha512-tFeBDgww/lCWgk1YL7aYX99qKaZxYHwUPJigzdw9HQtlSiUsiBsTl+Y+cVeZJmqBD2us/NUraCMhVd5otse5Zw==}
     dependencies:
       '@changesets/cli': 2.27.7
       '@types/uuid': 8.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.27.4-org-retarget-beta.4
-        version: 3.27.4-org-retarget-beta.4
+        specifier: 3.27.4-org-retarget-beta.8
+        version: 3.27.4-org-retarget-beta.8
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -8354,8 +8354,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.27.4-org-retarget-beta.4:
-    resolution: {integrity: sha512-mdyN2klNnA8XjgeRNkqvaKpR/GQCUTPmtH/W//YRrB4G8PfoukroQ8zETQvdRBY1egpFBMZkDaFwWKCnZ69OKQ==}
+  /@slashid/slashid@3.27.4-org-retarget-beta.8:
+    resolution: {integrity: sha512-IPW57L3cA49lJkByHyzdPUsa1pKz6tPJQQ3fjwzySqLBla90DXzg38jJ6uXyS3pEo+hVrIE7HUZ8lMXTYB0T5A==}
     dependencies:
       '@changesets/cli': 2.27.7
       '@types/uuid': 8.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: ^8.0.2
         version: 8.3.1
       '@slashid/slashid':
-        specifier: 3.27.4-org-retarget-beta.9
-        version: 3.27.4-org-retarget-beta.9
+        specifier: 3.28.0
+        version: 3.28.0
       '@storybook/addon-essentials':
         specifier: 7.6.19
         version: 7.6.19(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -613,8 +613,8 @@ importers:
         specifier: workspace:*
         version: link:../react
       '@slashid/slashid':
-        specifier: 3.27.1
-        version: 3.27.1
+        specifier: 3.28.0
+        version: 3.28.0
       jose:
         specifier: ^5.2.0
         version: 5.2.0
@@ -8338,8 +8338,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@slashid/slashid@3.27.1:
-    resolution: {integrity: sha512-b7t+S55w8nw2oIpBZn2V22alpuVoy/Tn4febzqN4kWkbBqsMN89ype40n1Xb7e0PWwS+oNdIG79fGdO8IYOKLQ==}
+  /@slashid/slashid@3.28.0:
+    resolution: {integrity: sha512-AX0aSrgfFkG9iwzgQDK6h+hbJOmbRkX+CyKuJYAxyOFfjpvEZhGg5Y3RuClo9BCBWdRrc9VhSho2iycwP3TNVw==}
     dependencies:
       '@changesets/cli': 2.27.7
       '@types/uuid': 8.3.4
@@ -8352,23 +8352,6 @@ packages:
       ua-parser-js: 1.0.37
       url: 0.11.3
       uuid: 8.3.2
-    dev: false
-
-  /@slashid/slashid@3.27.4-org-retarget-beta.9:
-    resolution: {integrity: sha512-tFeBDgww/lCWgk1YL7aYX99qKaZxYHwUPJigzdw9HQtlSiUsiBsTl+Y+cVeZJmqBD2us/NUraCMhVd5otse5Zw==}
-    dependencies:
-      '@changesets/cli': 2.27.7
-      '@types/uuid': 8.3.4
-      compare-versions: 6.1.0
-      docdash: 1.2.0
-      jwt-decode: 3.1.2
-      qrcode: 1.5.3
-      querystring-es3: 0.2.1
-      regenerator-runtime: 0.13.11
-      ua-parser-js: 1.0.37
-      url: 0.11.3
-      uuid: 8.3.2
-    dev: true
 
   /@storybook/addon-actions@7.6.19:
     resolution: {integrity: sha512-ATLrA5QKFJt7tIAScRHz5T3eBQ+RG3jaZk08L7gChvyQZhei8knWwePElZ7GaWbCr9BgznQp1lQUUXq/UUblAQ==}


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-2019)

It is possible to miss events published by the core SDK due to race conditions. Having an event buffer makes this less likely to happen as it will replay the events that happened prior the subscription.

With this PR the React SDK will be able to buffer events that were published before any listeners had any chance to process these events. It uses that mechanism to listen to the new event type that establishes the authentication context upon processing the related challenge.

This is a big change, since previously the authentication context was established by the values submitted in the initial step. Now that this can be changed using a sync webhook,  we need to wait for the core SDK to tell us what the auth context it.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
