### PR TITLE
React: users re-authenticated via `initialToken` prop now emit the `PersonIdentified_v1` event.

### DIFF
--- a/.changeset/dry-camels-bake.md
+++ b/.changeset/dry-camels-bake.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Users re-authenticated via initialToken prop now emit the `PersonIdentified_v1` event.

--- a/packages/react-primitives/src/components/text/text.css.ts
+++ b/packages/react-primitives/src/components/text/text.css.ts
@@ -9,7 +9,7 @@ export const text = recipe({
     color: publicVariables.color.foreground,
     margin: 0,
     lineHeight: "100%",
-    whiteSpace: "pre-wrap"
+    whiteSpace: "pre-wrap",
   },
 
   variants: {

--- a/packages/react/src/components/dynamic-flow/handle-form.tsx
+++ b/packages/react/src/components/dynamic-flow/handle-form.tsx
@@ -162,7 +162,7 @@ export const HandleForm: React.FC<Props> = ({
     values,
     defaultValue,
     parsedPhoneNumber,
-    showFactorsOnly
+    showFactorsOnly,
   ]);
 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {

--- a/packages/react/src/components/form/authenticating/index.tsx
+++ b/packages/react/src/components/form/authenticating/index.tsx
@@ -120,7 +120,9 @@ export function Authenticating({ children }: AuthenticatingTemplateProps) {
 
 export type AuthenticatingProps = Pick<Props, "flowState">;
 
-export const AuthenticatingImplementation = ({ flowState }: AuthenticatingProps) => {
+export const AuthenticatingImplementation = ({
+  flowState,
+}: AuthenticatingProps) => {
   const factor = flowState.context.config.factor;
   const attempt = useRef(1);
   const isLoggingIn = useRef(false);

--- a/packages/react/src/context/slash-id-context.tsx
+++ b/packages/react/src/context/slash-id-context.tsx
@@ -415,6 +415,31 @@ export const SlashIDProvider = ({
     [anonymousUsersEnabled, storeAnonymousUser, storeUser]
   );
 
+  /**
+   * In most cases user identification happens in `@slashid/slashid`
+   * during authentication, the exception are when users are
+   * "re-authenticated" using a stored token.
+   *
+   * In `@slashid/react` this happens in one of two scenarios:
+   * - Token is provided as `initialToken` prop
+   * - Token is discovered in storage i.e. `storage.getItem(STORAGE_TOKEN_KEY)`
+   */
+  const identifyUser = useCallback(
+    (user: User | AnonymousUser | null) => {
+      if (user && analyticsEnabled) {
+        try {
+          // in all other cases the core SDK will handle this
+          // here we just recreate the user object based on the preexisting token
+          // no event is emitted on the SDK side because of that
+          sidRef.current?.getAnalytics().identify(user);
+        } catch {
+          // fail silently
+        }
+      }
+    },
+    [analyticsEnabled]
+  );
+
   useEffect(() => {
     if (state !== "loaded") {
       return;
@@ -427,7 +452,11 @@ export const SlashIDProvider = ({
       const isTokenValid = token && (await validateToken(token));
       if (!isTokenValid) return null;
 
-      return createAndStoreUserFromToken(token);
+      const user = createAndStoreUserFromToken(token);
+
+      identifyUser(user);
+
+      return user;
     };
 
     const loginWithDirectID = async () => {
@@ -458,16 +487,7 @@ export const SlashIDProvider = ({
 
       const user = createAndStoreUserFromToken(tokenFromStorage);
 
-      if (user && analyticsEnabled) {
-        try {
-          // in all other cases the core SDK will handle this
-          // here we just recreate the user object based on the preexisting token
-          // no event is emitted on the SDK side because of that
-          sidRef.current?.getAnalytics().identify(user);
-        } catch {
-          // fail silently
-        }
-      }
+      identifyUser(user);
 
       return user;
     };


### PR DESCRIPTION
Context here: https://slashidworkspace.slack.com/archives/C05GXCMLGVA/p1734363971363839

We have a missed case where we do not correctly record "user identified" event