### PR TITLE
React SDK: Add line-height for select label

### DIFF
--- a/.changeset/cyan-bears-shout.md
+++ b/.changeset/cyan-bears-shout.md
@@ -1,0 +1,6 @@
+---
+"@slashid/react-primitives": patch
+"@slashid/react": patch
+---
+
+Fix the line-height of select label for CSS reset

--- a/packages/react-primitives/src/components/dropdown/dropdown.css.ts
+++ b/packages/react-primitives/src/components/dropdown/dropdown.css.ts
@@ -36,6 +36,7 @@ export const trigger = style({
 export const label = style({
   fontSize: theme.font.size.xs,
   fontWeight: theme.font.weight.semibold,
+  lineHeight: "118%",
   color: publicVariables.input.label.color,
   position: "absolute",
   top: 12,

--- a/packages/react-primitives/src/components/tabs/tabs.css.ts
+++ b/packages/react-primitives/src/components/tabs/tabs.css.ts
@@ -18,6 +18,7 @@ export const trigger = style({
   justifyContent: "center",
   flex: "1",
   textAlign: "center",
+  lineHeight: "118%",
 
   selectors: {
     '&[data-state="active"]': {

--- a/packages/react/src/dev.css
+++ b/packages/react/src/dev.css
@@ -4,6 +4,7 @@
   place-items: center;
   min-height: 100vh;
   width: 100%;
+  line-height: 0;
 }
 
 body {


### PR DESCRIPTION
## Description



## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
