### PR TITLE
[SID-2056] React SDK: back button blocked

### DIFF
--- a/.changeset/curvy-owls-repair.md
+++ b/.changeset/curvy-owls-repair.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Fixed: event buffer wasn't buffering events after all subscribers stopped listening for a particular event

--- a/packages/react/src/components/form/event-buffer.test.ts
+++ b/packages/react/src/components/form/event-buffer.test.ts
@@ -85,7 +85,7 @@ describe("createEventBuffer", () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it.only("should buffer events after all subscribers unsubscribe from an event and replay them to the first subscriber", () => {
+  it("should buffer events after all subscribers unsubscribe from an event and replay them to the first subscriber", () => {
     const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
     const eventBuffer = createEventBuffer({ sdk });
     const callback = vi.fn();

--- a/packages/react/src/components/form/event-buffer.test.ts
+++ b/packages/react/src/components/form/event-buffer.test.ts
@@ -85,6 +85,44 @@ describe("createEventBuffer", () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  it.only("should buffer events after all subscribers unsubscribe from an event and replay them to the first subscriber", () => {
+    const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
+    const eventBuffer = createEventBuffer({ sdk });
+    const callback = vi.fn();
+
+    // subscribe
+    eventBuffer.subscribe("authnContextUpdateChallengeReceivedEvent", callback);
+
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "1",
+    });
+
+    // unsubscribe
+    eventBuffer.unsubscribe(
+      "authnContextUpdateChallengeReceivedEvent",
+      callback
+    );
+    sdk.mockPublish("authnContextUpdateChallengeReceivedEvent", {
+      targetOrgId: "2",
+    });
+
+    expect(callback).toHaveBeenLastCalledWith({
+      targetOrgId: "1",
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // subscribe again
+    // there was a bug where we incorrectly managed internal state and didn't buffer events after the last subscriber unsubscribed
+    eventBuffer.subscribe("authnContextUpdateChallengeReceivedEvent", callback);
+
+    // this should replay the event that was missed
+
+    expect(callback).toHaveBeenLastCalledWith({
+      targetOrgId: "2",
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
   it("should only let the first subscriber consume the buffered events", () => {
     const sdk = new MockSlashID({ analyticsEnabled: false, oid: "test" });
     const eventBuffer = createEventBuffer({ sdk });

--- a/packages/react/src/components/form/event-buffer.ts
+++ b/packages/react/src/components/form/event-buffer.ts
@@ -26,7 +26,10 @@ export function createEventBuffer({ sdk }: CreateEventBufferArgs): EventBuffer {
   Utils.PUBLIC_READ_EVENTS.forEach((publicReadEventName: EventNames) => {
     // create an event handler
     const handler = (event: Event) => {
-      if (subscribers.has(publicReadEventName)) {
+      if (
+        subscribers.has(publicReadEventName) &&
+        subscribers.get(publicReadEventName)?.length
+      ) {
         // if there is a subscriber for this event type just ignore
         return;
       }
@@ -79,7 +82,7 @@ export function createEventBuffer({ sdk }: CreateEventBufferArgs): EventBuffer {
   function unsubscribe(eventType: EventNames, callback: EventCallback) {
     sdk.unsubscribe(eventType, callback);
 
-    if (!subscribers.has(eventType)) {
+    if (!subscribers.has(eventType) || !subscribers.get(eventType)?.length) {
       return;
     }
 


### PR DESCRIPTION
## Description

[YouTrack issue](https://todo.irdcorp.dev/issue/SID-2056)

When the last subscriber of an event type would unsubscribe, the event buffer was supposed to buffer any future instances of this event type and replay them to the first subscriber. Due to a bad state check this wouldn't happen if you had already subscribed to this event type, unsubscribed and then subscribed again.

This issue is now fixed and a unit test was added that confirms this.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
