### PR TITLE
[Bugfix] Email addresses should be normalised before validation

### DIFF
--- a/.changeset/wet-hotels-bow.md
+++ b/.changeset/wet-hotels-bow.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Normalise the email before validation

--- a/packages/react/src/components/form/authenticating/validation.test.ts
+++ b/packages/react/src/components/form/authenticating/validation.test.ts
@@ -102,4 +102,9 @@ describe.concurrent("validation tests", () => {
   it("should be invalid phone number", () => {
     expect(isValidPhoneNumber("")).toBe(false);
   });
+
+  it("should allow mixed case", () => {
+    expect(isValidEmail("JEssica.e@h.com")).toBe(true);
+    expect(isValidEmail("Jessica.E@h.com")).toBe(true);
+  });
 });

--- a/packages/react/src/components/form/authenticating/validation.ts
+++ b/packages/react/src/components/form/authenticating/validation.ts
@@ -22,7 +22,7 @@ export const isValidEmail: ValidatorFn<string> = (value) => {
     return false;
   }
 
-  return EMAIL_REGEX.test(value);
+  return EMAIL_REGEX.test(value.toLowerCase());
 };
 
 export const isValidUsername: ValidatorFn<string> = (value) => {


### PR DESCRIPTION
## Description

The BE normalises the email address value before validating it. We use the same regex, but the FE did not perform normalization. Now we lowercase all the characters before validating, removing false positives.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
