### PR TITLE
Ensure that peer deps are externalized

### DIFF
--- a/.changeset/nine-rats-judge.md
+++ b/.changeset/nine-rats-judge.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Properly externalize deps

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   bundle-size:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [20.9.0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: "mcr.microsoft.com/playwright:v1.42.1-jammy"
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     name: Release
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -2,6 +2,8 @@ import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import { config } from "./vite.shared";
 
+import * as packageJson from "./package.json";
+
 export default defineConfig({
   ...config,
   build: {
@@ -11,8 +13,13 @@ export default defineConfig({
       fileName: `main`,
     },
     rollupOptions: {
-      // these must appear exactly as imported => having react here won't prevent react/jsx-runtime being bundled, so it must be explicit
-      external: ["react", "react/jsx-runtime", "react-dom", "react-dom/client"],
+      external: [
+        // include all the keys from peerDependencies by default
+        ...Object.keys(packageJson.peerDependencies),
+        // these must be specified explicitly as they are not matched by react and react-dom from peer deps
+        "react/jsx-runtime",
+        "react-dom/client",
+      ],
     },
     sourcemap: true,
   },


### PR DESCRIPTION
## Description

Previous PR had the `@slashid/slash` module being included in the bundle while it is supposed to be external.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
