### PR TITLE
[Bugfix] Ensure the org switch flow works with redirect

### DIFF
--- a/.changeset/tricky-gifts-compare.md
+++ b/.changeset/tricky-gifts-compare.md
@@ -1,0 +1,5 @@
+---
+"@slashid/react": patch
+---
+
+Fix the issue with HRD and SSO in redirect mode

--- a/packages/react/src/domain/org.ts
+++ b/packages/react/src/domain/org.ts
@@ -1,0 +1,49 @@
+import { AnonymousUser, User } from "@slashid/slashid";
+
+export const LEGACY_STORAGE_TOKEN_KEY = "@slashid/USER_TOKEN";
+
+export const STORAGE_TOKEN_KEY = (oid: string) =>
+  `${LEGACY_STORAGE_TOKEN_KEY}/${oid}`;
+
+export const ORG_SWITCHING_FLAG_KEY = "@slashid/ORG_SWITCHING_FLOW";
+
+export function getStorageKeyForOrgSwitchingUser(user: User | AnonymousUser) {
+  if (sessionStorage && sessionStorage.getItem(ORG_SWITCHING_FLAG_KEY)) {
+    return STORAGE_TOKEN_KEY(user.oid);
+  }
+}
+
+/**
+ * When using SSO in org switching flows with Home Realm Discovery,
+ * redirect UX mode will cause the SDK not to switch to the proper org upon returning to the redirect URL.
+ *
+ * To fix that, we raise a flag in session storage and ensure the flow is done once we load the page again.
+ */
+export function raiseOrgSwitchingFlag() {
+  if (sessionStorage) {
+    sessionStorage.setItem(ORG_SWITCHING_FLAG_KEY, "in_progress");
+  }
+}
+
+export function clearOrgSwitchingFlag() {
+  if (sessionStorage) {
+    sessionStorage.removeItem(ORG_SWITCHING_FLAG_KEY);
+  }
+}
+
+export function shouldResumeOrgSwitchingFlow(
+  oid: string,
+  user: User | AnonymousUser | undefined | null
+) {
+  if (
+    sessionStorage &&
+    sessionStorage.getItem(ORG_SWITCHING_FLAG_KEY) &&
+    user &&
+    oid !== user.oid
+  ) {
+    return true;
+  }
+
+  clearOrgSwitchingFlag();
+  return false;
+}

--- a/packages/react/src/tests/anonymous-users.test.tsx
+++ b/packages/react/src/tests/anonymous-users.test.tsx
@@ -4,7 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useSlashID, SlashIDProvider } from "../main";
 import { createAnonymousTestUser } from "../components/test-utils";
 import { SlashID } from "@slashid/slashid";
-import { STORAGE_TOKEN_KEY } from "../context/slash-id-context";
+import { STORAGE_TOKEN_KEY } from "../domain/org";
 
 describe("Anonymous users", () => {
   afterEach(() => {

--- a/packages/react/src/tests/token-storage.test.tsx
+++ b/packages/react/src/tests/token-storage.test.tsx
@@ -7,11 +7,9 @@ import {
   useSlashID,
 } from "../main";
 import { createTestUser, TEST_ORG_ID } from "../components/test-utils";
-import {
-  LEGACY_STORAGE_TOKEN_KEY,
-  STORAGE_TOKEN_KEY,
-} from "../context/slash-id-context";
+
 import userEvent from "@testing-library/user-event";
+import { STORAGE_TOKEN_KEY, LEGACY_STORAGE_TOKEN_KEY } from "../domain/org";
 
 describe("token storage key with org id suffix", () => {
   const getItemSpy = vi.spyOn(Storage.prototype, "getItem");


### PR DESCRIPTION
## Description

When the org switching flow involves a redirect (in case of SSO via OIDC/SAML), the SDK would not finish the flow properly as after loading the page again it loses any in-memory context.

Specifically, we observed this sequence of events in the SlashID Console:
- a user logs in to the root dashboard org (local storage has the token stored under root oid)
- then they switch to the target org
- assuming SAML is configured properly, they get redirected to the IdPs login page
- after successful auth they are redirected back to the Console

Then the SDK does the following:
- there are challenges in the URL so it resolves them, obtaining a new token for the target org
- since the OID hasn't changed, the new token is stored under the initial OID, which is the root org ID
- then the Console initiates the org switch, but the SDK cannot find the token for the target org as it was stored under the root org ID

To fix this, this PR adds a flag that uses `sessionStorage` to survive the redirect and tell the SDK to store the new token under the target org namespace.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
