### PR TITLE
Add the onInitError callback

### DIFF
--- a/packages/react/src/components/onboarding/onboarding-form.component.tsx
+++ b/packages/react/src/components/onboarding/onboarding-form.component.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { useSlashID } from "../../main";
 import { Form } from "../form";
 import { useOnboarding } from "./onboarding-context.hook";
+import { useSlashID } from "../../hooks/use-slash-id";
 
 export function OnboardingForm() {
   const id = "onboarding-login-form";

--- a/packages/react/src/components/onboarding/onboarding.component.tsx
+++ b/packages/react/src/components/onboarding/onboarding.component.tsx
@@ -1,9 +1,9 @@
 import { createContext, useEffect, useMemo, useState } from "react";
 import { OnboardingAPI, OnboardingState } from "./onboarding.types";
 import { AnonymousUser, Errors, JsonObject } from "@slashid/slashid";
-import { useSlashID } from "../../main";
 import { ensureError } from "../../domain/errors";
 import { Loading } from "@slashid/react-primitives";
+import { useSlashID } from "../../hooks/use-slash-id";
 
 const initialOnboardingState: OnboardingState = {
   currentStepId: "",

--- a/packages/react/src/context/slash-id-context.test.tsx
+++ b/packages/react/src/context/slash-id-context.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { SlashIDProviderImplementation } from "./slash-id-context";
+import { MockSlashID } from "../components/test-utils";
+import type { SlashIDOptions } from "@slashid/slashid";
+
+describe("Lifecycle methods", () => {
+  it("calls onInitError if getUserFromURL throws", async () => {
+    const error = new Error("getUserFromURL error");
+    const createSlashID = (options: SlashIDOptions) => {
+      const mockSid = new MockSlashID(options);
+      mockSid.getUserFromURL = jest.fn().mockRejectedValue(error);
+      return mockSid;
+    };
+
+    const onInitError = jest.fn();
+
+    render(
+      <SlashIDProviderImplementation
+        createSlashID={createSlashID}
+        onInitError={onInitError}
+        oid="test-oid"
+        analyticsEnabled={false}
+        tokenStorage="memory"
+      >
+        Test
+      </SlashIDProviderImplementation>
+    );
+
+    await waitFor(() => {
+      expect(onInitError).toHaveBeenCalledWith(error);
+    });
+  });
+
+  it("calls onInitError if createAnonymousUser throws", async () => {
+    const error = new Error("createAnonymousUser error");
+    const createSlashID = (options: SlashIDOptions) => {
+      const mockSid = new MockSlashID(options);
+      mockSid.getUserFromURL = jest.fn().mockResolvedValue(null);
+      mockSid.createAnonymousUser = jest.fn().mockRejectedValue(error);
+      return mockSid;
+    };
+
+    const onInitError = jest.fn();
+
+    render(
+      <SlashIDProviderImplementation
+        createSlashID={createSlashID}
+        onInitError={onInitError}
+        oid="test-oid"
+        analyticsEnabled={false}
+        tokenStorage="memory"
+        anonymousUsersEnabled
+      >
+        Test
+      </SlashIDProviderImplementation>
+    );
+
+    await waitFor(() => {
+      expect(onInitError).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/packages/react/src/context/slash-id-context.test.tsx
+++ b/packages/react/src/context/slash-id-context.test.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { SlashIDProviderImplementation } from "./slash-id-context";
 import { MockSlashID } from "../components/test-utils";
 import type { SlashIDOptions } from "@slashid/slashid";
@@ -30,6 +29,7 @@ describe("Lifecycle methods", () => {
     await waitFor(() => {
       expect(onInitError).toHaveBeenCalledWith(error);
     });
+    expect(screen.getByText("Test")).toBeInTheDocument();
   });
 
   it("calls onInitError if createAnonymousUser throws", async () => {
@@ -59,5 +59,6 @@ describe("Lifecycle methods", () => {
     await waitFor(() => {
       expect(onInitError).toHaveBeenCalledWith(error);
     });
+    expect(screen.getByText("Test")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

When initialising the SDK we try to hydrate the user token from several sources. Some of this attempts may fail, for example when parsing the URL for challenges we might encounter an incorrectly formatted challenge pack or an expired challenge ID.

The SDK will resume its lifecycle as if nothing happened, but it is useful for client apps to know if something went wrong so this PR exposes the `onInitError` callback for that purpose. The behaviour remains unchanged.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have generated the new version of the docs website and smoke tested it
- [ ] I have checked that my changes haven't caused semantic errors in the existing docs
- [ ] I have generated a `changeset` if my change affects the published packages
